### PR TITLE
Add SBoM generation and antimalware tasks

### DIFF
--- a/.azure-pipelines/compliance/compliance.yml
+++ b/.azure-pipelines/compliance/compliance.yml
@@ -41,7 +41,7 @@ steps:
     condition: and(ne(variables['System.PullRequest.IsFork'], 'True'), eq(variables['Agent.OS'], 'Linux'), in(variables['Build.Reason'], 'Manual', 'Schedule')) # Only on scheduled and manual builds because it is slow
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Package'
+    displayName: 'Publish SBoM'
     inputs:
       PathtoPublish: '$(build.artifactstagingdirectory)/_manifest'
       ArtifactName: '_manifest'


### PR DESCRIPTION
Identical to https://github.com/microsoft/compose-language-service/pull/66.

Sample build run: https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=41368&view=results

I fixed the "Publish SBoM" step name after this run but figured it was not necessary to re-run.