### PR TITLE
Fix image inspect bug

### DIFF
--- a/packages/container-runtimes/src/clients/DockerLikeClient/DockerInspectImageRecord.ts
+++ b/packages/container-runtimes/src/clients/DockerLikeClient/DockerInspectImageRecord.ts
@@ -52,7 +52,7 @@ export function isDockerInspectImageRecord(maybeImage: unknown): maybeImage is D
         return false;
     }
 
-    if (!Array.isArray(image.Command)) {
+    if (image.Command !== null && !Array.isArray(image.Command)) {
         return false;
     }
 


### PR DESCRIPTION
Fixes a bug I hit on image inspect. The image I built had no command, only an entrypoint.