### PR TITLE
Fix a bug in file streaming command

### DIFF
--- a/packages/container-runtimes/src/clients/DockerClientBase/DockerClientBase.ts
+++ b/packages/container-runtimes/src/clients/DockerClientBase/DockerClientBase.ts
@@ -2094,6 +2094,7 @@ export abstract class DockerClientBase extends ConfigurableClient implements ICo
             return composeArgs(
                 withArg('cp'),
                 withContainerPathArg(options),
+                withArg('-'),
             )();
         }
     }


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/microsoft/vscode-docker-extensibility/pull/125/files#diff-a2a5e322830269924231075f3bad0a78ef2b63e182c60c75eb4392c22f3ec5a8L2056. That line should not have been removed completely; instead, the file output should have been sent to stdout.