### PR TITLE
Add back Docker extension export helpers

### DIFF
--- a/packages/container-runtimes/src/contracts/DockerExtensionExport.ts
+++ b/packages/container-runtimes/src/contracts/DockerExtensionExport.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { IContainersClient } from './ContainerClient';
+import { IContainerOrchestratorClient } from './ContainerOrchestratorClient';
+
+/**
+ * This interface is implemented by the Docker extension. To access it, use {@link getDockerExtensionExport}
+ * below. Alternatively, use the
+ * [extension API](https://code.visualstudio.com/api/references/vscode-api#extensions), with
+ * the ID of the Docker extension (`ms-azuretools.vscode-docker`).
+ */
+export interface DockerExtensionExport {
+    /**
+     * Registers a container runtime client with the Docker extension
+     * @param client The client implementing the {@link IContainersClient} interface
+     * @returns A {@link Disposable} that, when disposed, will undo the client registration
+     */
+    registerContainerRuntimeClient(client: IContainersClient): vscode.Disposable;
+
+    /**
+     * Registers a container orchestrator client with the Docker extension
+     * @param client The client implementing the {@link IContainerOrchestratorClient} interface
+     * @returns A {@link Disposable} that, when disposed, will undo the client registration
+     */
+    registerContainerOrchestratorClient(client: IContainerOrchestratorClient): vscode.Disposable;
+}
+
+/**
+ * Gets the Docker extension's exports, activating it if necessary.
+ * @returns The {@link DockerExtensionExport} export for the Docker extension
+ * @throws An error if the Docker extension is not installed or not enabled
+ */
+export async function getDockerExtensionExport(): Promise<DockerExtensionExport> {
+    const dockerExtensionId = 'ms-azuretools.vscode-docker';
+    const dockerExtension = vscode.extensions.getExtension<DockerExtensionExport>(dockerExtensionId);
+
+    if (!dockerExtension) {
+        throw new Error(`The extension '${dockerExtensionId}' is not installed or not enabled.`);
+    }
+
+    if (!dockerExtension.isActive) {
+        await dockerExtension.activate();
+    }
+
+    return dockerExtension.exports;
+}

--- a/packages/container-runtimes/src/index.ts
+++ b/packages/container-runtimes/src/index.ts
@@ -11,6 +11,7 @@ export * from './commandRunners/wslStream';
 export * from './contracts/CommandRunner';
 export * from './contracts/ContainerClient';
 export * from './contracts/ContainerOrchestratorClient';
+export * from './contracts/DockerExtensionExport';
 export * from './typings/CancellationTokenLike';
 export * from './typings/DisposableLike';
 export * from './typings/EventLike';


### PR DESCRIPTION
Added back (with some slight changes) from https://github.com/microsoft/vscode-docker-extensibility/blob/331e3b9b9506d1ad3251e9f6a011d468cdda31cd/packages/container-runtimes/src/contracts/DockerExtensionExport.ts