### PR TITLE
Added delete image & get digest logic for Generic V2

### DIFF
--- a/packages/vscode-docker-registries/src/clients/GenericRegistryV2/GenericRegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/GenericRegistryV2/GenericRegistryV2DataProvider.ts
@@ -9,8 +9,6 @@ import { BasicOAuthProvider } from '../../auth/BasicOAuthProvider';
 import { GenericRegistryV2WizardContext, GenericRegistryV2WizardPromptStep } from './GenericRegistryV2WizardPromptStep';
 import { RegistryWizard } from '../../wizard/RegistryWizard';
 import { RegistryWizardSecretPromptStep, RegistryWizardUsernamePromptStep } from '../../wizard/RegistryWizardPromptStep';
-import { CommonTag } from '../Common/models';
-import { registryV2Request } from '../RegistryV2/registryV2Request';
 
 const GenericV2StorageKey = 'GenericV2ContainerRegistry';
 const TrackedRegistriesKey = `${GenericV2StorageKey}.TrackedRegistries`;
@@ -150,41 +148,5 @@ export class GenericRegistryV2DataProvider extends RegistryV2DataProvider {
         await this.authenticationProviders.get(registryUriString)?.removeSession();
         this.authenticationProviders.delete(registryUriString);
         // TODO: check if the map of auth providers is empty, if so, remove the root from the tree
-    }
-
-    public async deleteTag(item: CommonTag): Promise<void> {
-        const digest = await this.getImageDigest(item);
-        const registry = item.parent.parent as unknown as GenericV2Registry;
-        await registryV2Request({
-            authenticationProvider: this.getAuthenticationProvider(registry),
-            method: 'DELETE',
-            registryUri: registry.baseUrl,
-            path: ['v2', item.parent.label, 'manifests', digest],
-            scopes: [`repository:${item.parent.label}:pull`],
-            headers: {
-                'accept': 'application/vnd.docker.distribution.manifest.v2+json'
-            }
-        });
-    }
-
-    public async getImageDigest(item: CommonTag): Promise<string> {
-        const registry = item.parent.parent as unknown as GenericV2Registry;
-        const response = await registryV2Request({
-            authenticationProvider: this.getAuthenticationProvider(registry),
-            method: 'GET',
-            registryUri: registry.baseUrl,
-            path: ['v2', item.parent.label, 'manifests', item.label],
-            scopes: [`repository:${item.parent.label}:pull`],
-            headers: {
-                'accept': 'application/vnd.docker.distribution.manifest.v2+json'
-            }
-        });
-
-        const digest = response.headers['docker-content-digest'];
-        if (!digest) {
-            throw new Error('Could not find digest');
-        }
-
-        return digest;
     }
 }

--- a/packages/vscode-docker-registries/src/clients/GitHub/GitHubRegistryDataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/GitHub/GitHubRegistryDataProvider.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { BasicOAuthProvider } from '../../auth/BasicOAuthProvider';
-import { RegistryV2DataProvider, V2Registry, V2RegistryItem, V2RegistryRoot, V2Repository } from '../RegistryV2/RegistryV2DataProvider';
+import { RegistryV2DataProvider, V2Registry, V2RegistryItem, V2RegistryRoot, V2Repository, V2Tag } from '../RegistryV2/RegistryV2DataProvider';
 import { registryV2Request } from '../RegistryV2/registryV2Request';
 import { AuthenticationProvider } from '../../contracts/AuthenticationProvider';
 import { httpRequest } from '../../utils/httpRequest';
@@ -118,6 +118,16 @@ export class GitHubRegistryDataProvider extends RegistryV2DataProvider {
         } while (!foundAllInSearch);
 
         return results;
+    }
+
+    public async getTags(repository: V2Repository): Promise<V2Tag[]> {
+        const tags = await super.getTags(repository);
+        const tagsWithAdditionalContext: V2Tag[] = tags.map(tag => ({
+            ...tag,
+            additionalContextValues: ['githubRegistryTag']
+        }));
+
+        return tagsWithAdditionalContext;
     }
 
     protected getAuthenticationProvider(item: V2RegistryItem): AuthenticationProvider<never> {


### PR DESCRIPTION
This PR mainly addressed adding delete image & get digest logic for Generic V2

I also refactored some of the naming in GenericV2DP since the names I previously gave things didn't really make sense. 

Related to https://github.com/microsoft/vscode-docker/pull/4026

