### PR TITLE
Added `UnauthorizedError` for Better Reconnect Experience

### DIFF
--- a/packages/vscode-docker-registries/src/clients/Common/CommonRegistryDataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/Common/CommonRegistryDataProvider.ts
@@ -10,6 +10,7 @@ import { getContextValue } from '../../utils/contextValues';
 import { LoginInformation } from '../../contracts/BasicCredentials';
 import * as dayjs from 'dayjs';
 import * as relativeTime from 'dayjs/plugin/relativeTime';
+import { getErrorTreeItem } from './ErrorTreeItem';
 
 dayjs.extend(relativeTime);
 
@@ -31,7 +32,7 @@ export abstract class CommonRegistryDataProvider implements RegistryDataProvider
                 throw new Error(`Unexpected element: ${JSON.stringify(element)}`);
             }
         } catch (error: unknown) {
-            return [this.getRegistryErrorItem(error, element)];
+            return getErrorTreeItem(error, element);
         }
     }
 
@@ -76,17 +77,6 @@ export abstract class CommonRegistryDataProvider implements RegistryDataProvider
         else {
             throw new Error(`Unexpected element: ${JSON.stringify(element)}`);
         }
-    }
-
-    public getRegistryErrorItem(error: unknown, parent: CommonRegistryItem | undefined): CommonError {
-        const errorMsg = error instanceof Error ? error.message : 'Unknown error';
-        const errorItem: CommonError = {
-            parent: parent,
-            label: errorMsg,
-            type: 'commonerror',
-        };
-
-        return errorItem;
     }
 
     public abstract readonly id: string;

--- a/packages/vscode-docker-registries/src/clients/Common/ErrorTreeItem.ts
+++ b/packages/vscode-docker-registries/src/clients/Common/ErrorTreeItem.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { isUnauthorizedError } from "../../utils/errors";
 import { CommonError, CommonRegistryItem } from "./models";
 
 export interface RegistryConnectError extends CommonError {
@@ -12,24 +13,22 @@ export interface RegistryConnectError extends CommonError {
 }
 
 export function getErrorTreeItem(error: unknown, parent: CommonRegistryItem | undefined): CommonError[] {
-    const errorMsg = error instanceof Error ? error.message : 'Unknown error';
-    const errorType = error instanceof Error ? error.name : 'Unknown error';
 
     // if the error is an Unauthorized error, return a special error type
-    if (errorMsg.includes('Unauthorized') || errorType === 'UnauthorizedError') {
+    if (isUnauthorizedError(error)) {
         return [{
             parent,
-            label: errorMsg,
+            label: error.message,
             type: 'commonerror',
-            description: 'Connect to Registry',
             additionalContextValues: ['registryConnectError'],
         }];
     }
 
+
     // otherwise, return a generic error
     return [{
         parent: parent,
-        label: errorMsg,
+        label: error instanceof Error ? error.message : 'Unknown error',
         type: 'commonerror',
     }];
 }

--- a/packages/vscode-docker-registries/src/clients/Common/ErrorTreeItem.ts
+++ b/packages/vscode-docker-registries/src/clients/Common/ErrorTreeItem.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CommonError, CommonRegistryItem } from "./models";
+
+export interface RegistryConnectError extends CommonError {
+    readonly parent: CommonRegistryItem | undefined;
+    readonly type: 'commonerror';
+    readonly additionalContextValues: ['registryConnectError'];
+}
+
+export function getErrorTreeItem(error: unknown, parent: CommonRegistryItem | undefined): CommonError[] {
+    const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+    const errorType = error instanceof Error ? error.name : 'Unknown error';
+
+    // if the error is an Unauthorized error, return a special error type
+    if (errorMsg.includes('Unauthorized') || errorType === 'UnauthorizedError') {
+        return [{
+            parent,
+            label: errorMsg,
+            type: 'commonerror',
+            description: 'Connect to Registry',
+            additionalContextValues: ['registryConnectError'],
+        }];
+    }
+
+    // otherwise, return a generic error
+    return [{
+        parent: parent,
+        label: errorMsg,
+        type: 'commonerror',
+    }];
+}

--- a/packages/vscode-docker-registries/src/clients/GenericRegistryV2/GenericRegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/GenericRegistryV2/GenericRegistryV2DataProvider.ts
@@ -17,7 +17,7 @@ interface GenericV2RegistryRoot extends V2RegistryRoot {
     readonly additionalContextValues: ['genericRegistryV2Root'];
 }
 
-interface GenericV2Registry extends V2Registry {
+export interface GenericV2Registry extends V2Registry {
     readonly additionalContextValues: ['genericRegistryV2Registry'];
 }
 

--- a/packages/vscode-docker-registries/src/clients/RegistryV2/registryV2Request.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/registryV2Request.ts
@@ -59,19 +59,14 @@ async function registryV2RequestInternal<T>(options: RegistryV2RequestOptions): 
     const auth = await options.authenticationProvider.getSession(options.scopes, options.sessionOptions);
     request.headers['Authorization'] = `${auth.type} ${auth.accessToken}`;
 
-    const response = await httpRequest(uri.toString(true), request);
-    const succeeded = response.status >= 200 && response.status < 300;
-
-    if (options.throwOnFailure && !succeeded) {
-        throw new Error(vscode.l10n.t('Request to {0} failed with response {1}: {2}', uri.toString(), response.status, response.statusText));
-    }
+    const response = await httpRequest(uri.toString(true), request, options.throwOnFailure);
 
     return {
         status: response.status,
         statusText: response.statusText,
-        succeeded: succeeded,
+        succeeded: response.succeeded,
         uri: uri,
         headers: response.headers,
-        body: succeeded && (parseInt(response.headers['content-length']) || response.headers['transfer-encoding'] === 'chunked') ? await response.json() as T : undefined,
+        body: response.succeeded && (parseInt(response.headers['content-length']) || response.headers['transfer-encoding'] === 'chunked') ? await response.json() as T : undefined,
     };
 }

--- a/packages/vscode-docker-registries/src/index.ts
+++ b/packages/vscode-docker-registries/src/index.ts
@@ -9,6 +9,7 @@ export * from './clients/RegistryV2/RegistryV2DataProvider';
 export * from './clients/RegistryV2/registryV2Request';
 export * from './clients/Common/CommonRegistryDataProvider';
 export * from './clients/Common/models';
+export * from './clients/Common/ErrorTreeItem';
 export * from './clients/DockerHub/DockerHubRegistryDataProvider';
 export * from './clients/GenericRegistryV2/GenericRegistryV2DataProvider';
 export * from './clients/GitHub/GitHubRegistryDataProvider';

--- a/packages/vscode-docker-registries/src/utils/errors.ts
+++ b/packages/vscode-docker-registries/src/utils/errors.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export class UnauthorizedError extends Error {
+    readonly name: 'UnauthorizedError';
+    constructor(message: string) {
+        super(message);
+        this.name = 'UnauthorizedError';
+    }
+}
+
+export function isUnauthorizedError(error: unknown): error is UnauthorizedError {
+    return !!error &&
+        typeof error === 'object' &&
+        'name' in error &&
+        error.name === 'UnauthorizedError';
+}

--- a/packages/vscode-docker-registries/src/utils/httpRequest.ts
+++ b/packages/vscode-docker-registries/src/utils/httpRequest.ts
@@ -27,6 +27,10 @@ export async function httpRequest<T>(url: string, request: RequestLike): Promise
         headers[header] = value;
     }
 
+    if (response.status === 401) {
+        throw new Error('Unauthorized request');
+    }
+
     return {
         ...response,
         headers: headers,

--- a/packages/vscode-docker-registries/src/utils/httpRequest.ts
+++ b/packages/vscode-docker-registries/src/utils/httpRequest.ts
@@ -16,10 +16,11 @@ export type ResponseLike<T> = ResponseInit & {
     headers: HeadersLike;
     status: number;
     statusText: string;
+    succeeded: boolean;
     json: () => Promise<T>;
 };
 
-export async function httpRequest<T>(url: string, request: RequestLike): Promise<ResponseLike<T>> {
+export async function httpRequest<T>(url: string, request: RequestLike, throwOnFailure: boolean = true): Promise<ResponseLike<T>> {
     const fetchRequest = new Request(url, request);
     const response: Response = await fetch(fetchRequest);
 
@@ -28,7 +29,7 @@ export async function httpRequest<T>(url: string, request: RequestLike): Promise
         headers[header] = value;
     }
 
-    if (response.status === 401) {
+    if (throwOnFailure && response.status === 401) {
         throw new UnauthorizedError(`Request to ${url} failed with status code 401: Unauthorized`);
     }
 
@@ -37,6 +38,7 @@ export async function httpRequest<T>(url: string, request: RequestLike): Promise
         headers: headers,
         status: response.status,
         statusText: response.statusText,
+        succeeded: response.status >= 200 && response.status < 300,
         json: response.json.bind(response),
     };
 }

--- a/packages/vscode-docker-registries/src/utils/httpRequest.ts
+++ b/packages/vscode-docker-registries/src/utils/httpRequest.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Request, RequestInit, Response, ResponseInit, default as fetch } from 'node-fetch';
+import { UnauthorizedError } from './errors';
 
 export type HeadersLike = Record<string, string>;
 
@@ -28,7 +29,7 @@ export async function httpRequest<T>(url: string, request: RequestLike): Promise
     }
 
     if (response.status === 401) {
-        throw new Error('Unauthorized request');
+        throw new UnauthorizedError(`Request to ${url} failed with status code 401: Unauthorized`);
     }
 
     return {


### PR DESCRIPTION
Added `UnauthorizedError` and its supporting functions. In vscode-docker, we can determine if an error is  `UnauthorizedError`, if so, we can show the reconnect command. 

Related to https://github.com/microsoft/vscode-docker/pull/4045