### PR TITLE
Make baseUrl Required

### DIFF
--- a/packages/vscode-docker-registries-extension/src/clients/Azure/AzureRegistryDataProvider.ts
+++ b/packages/vscode-docker-registries-extension/src/clients/Azure/AzureRegistryDataProvider.ts
@@ -163,6 +163,9 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
     }
 
     protected override getAuthenticationProvider(item: AzureRegistryItem): ACROAuthProvider {
+        if (!item.baseUrl) {
+            throw new Error(vscode.l10n.t('Registry does not have a base URL')); // this should never happen
+        }
         const registryString = item.baseUrl.toString();
 
         if (!this.authenticationProviders.has(registryString)) {

--- a/packages/vscode-docker-registries-extension/src/clients/GitLab/GitLabRegistryDataProvider.ts
+++ b/packages/vscode-docker-registries-extension/src/clients/GitLab/GitLabRegistryDataProvider.ts
@@ -93,6 +93,7 @@ export class GitLabRegistryDataProvider extends CommonRegistryDataProvider {
                     parent: root,
                     projectId: project.id,
                     type: 'commonregistry',
+                    baseUrl: GitLabBaseUrl
                 });
             }
         } while (!!nextLink);
@@ -124,6 +125,7 @@ export class GitLabRegistryDataProvider extends CommonRegistryDataProvider {
                     parent: registry,
                     type: 'commonrepository',
                     repositoryId: repository.id,
+                    baseUrl: registry.baseUrl,
                 });
 
             }
@@ -154,7 +156,8 @@ export class GitLabRegistryDataProvider extends CommonRegistryDataProvider {
                     label: tag.name,
                     parent: repository,
                     type: 'commontag',
-                    createdAt: await this.getTagDetails(tag.name, repository)
+                    createdAt: await this.getTagDetails(tag.name, repository),
+                    baseUrl: repository.baseUrl,
                 });
             }
         } while (!!nextLink);

--- a/packages/vscode-docker-registries/src/auth/DockerHubAuthProvider.ts
+++ b/packages/vscode-docker-registries/src/auth/DockerHubAuthProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { AuthenticationProvider } from '../contracts/AuthenticationProvider';
 import { LoginInformation } from '../contracts/BasicCredentials';
-import { DockerHubRequestUrl } from '../clients/DockerHub/DockerHubRegistryDataProvider';
+import { DockerHubRegistryUrl, DockerHubRequestUrl } from '../clients/DockerHub/DockerHubRegistryDataProvider';
 import { httpRequest } from '../utils/httpRequest';
 import { BasicAuthProvider } from './BasicAuthProvider';
 
@@ -50,11 +50,11 @@ export class DockerHubAuthProvider extends BasicAuthProvider implements Authenti
         };
     }
 
-    public async getLoginInformation?(): Promise<LoginInformation> {
+    public async getLoginInformation(): Promise<LoginInformation> {
         const credentials = await this.getBasicCredentials();
 
         return {
-            server: 'docker.io',
+            server: DockerHubRegistryUrl.toString(),
             username: credentials.username,
             secret: credentials.secret,
         };

--- a/packages/vscode-docker-registries/src/auth/DockerHubAuthProvider.ts
+++ b/packages/vscode-docker-registries/src/auth/DockerHubAuthProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { AuthenticationProvider } from '../contracts/AuthenticationProvider';
 import { LoginInformation } from '../contracts/BasicCredentials';
-import { DockerHubUrl } from '../clients/DockerHub/DockerHubRegistryDataProvider';
+import { DockerHubRequestUrl } from '../clients/DockerHub/DockerHubRegistryDataProvider';
 import { httpRequest } from '../utils/httpRequest';
 import { BasicAuthProvider } from './BasicAuthProvider';
 
@@ -22,7 +22,7 @@ export class DockerHubAuthProvider extends BasicAuthProvider implements Authenti
         const creds = await this.getBasicCredentials();
 
         if (!this.#token || options?.forceNewSession) {
-            const requestUrl = vscode.Uri.parse(DockerHubUrl)
+            const requestUrl = DockerHubRequestUrl
                 .with({ path: `v2/users/login` });
 
             const response = await httpRequest<{ token: string }>(requestUrl.toString(), {

--- a/packages/vscode-docker-registries/src/clients/Common/models.ts
+++ b/packages/vscode-docker-registries/src/clients/Common/models.ts
@@ -26,6 +26,7 @@ export function isRegistryRoot(maybeRegistryRoot: unknown): maybeRegistryRoot is
 export interface CommonRegistry extends CommonRegistryItem {
     readonly parent: CommonRegistryItem;
     readonly type: 'commonregistry';
+    readonly baseUrl: vscode.Uri;
 }
 
 export function isRegistry(maybeRegistry: unknown): maybeRegistry is CommonRegistry {
@@ -35,6 +36,7 @@ export function isRegistry(maybeRegistry: unknown): maybeRegistry is CommonRegis
 export interface CommonRepository extends CommonRegistryItem {
     readonly parent: CommonRegistry;
     readonly type: 'commonrepository';
+    readonly baseUrl: vscode.Uri;
 }
 
 export function isRepository(maybeRepository: unknown): maybeRepository is CommonRepository {
@@ -45,6 +47,7 @@ export interface CommonTag extends CommonRegistryItem {
     readonly parent: CommonRepository;
     readonly type: 'commontag';
     readonly createdAt?: Date;
+    readonly baseUrl: vscode.Uri;
 }
 
 export function isTag(maybeTag: unknown): maybeTag is CommonTag {

--- a/packages/vscode-docker-registries/src/clients/DockerHub/DockerHubRegistryDataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/DockerHub/DockerHubRegistryDataProvider.ts
@@ -10,7 +10,7 @@ import { RegistryWizard } from '../../wizard/RegistryWizard';
 import { RegistryWizardContext } from '../../wizard/RegistryWizardContext';
 import { RegistryWizardSecretPromptStep, RegistryWizardUsernamePromptStep } from '../../wizard/RegistryWizardPromptStep';
 import { CommonRegistryDataProvider } from '../Common/CommonRegistryDataProvider';
-import { CommonRegistryRoot, CommonRegistry, CommonRepository, CommonTag } from '../Common/models';
+import { CommonRegistryRoot, CommonRegistry, CommonRepository, CommonTag, CommonRegistryItem } from '../Common/models';
 
 import * as vscode from 'vscode';
 
@@ -157,13 +157,8 @@ export class DockerHubRegistryDataProvider extends CommonRegistryDataProvider {
         return results;
     }
 
-    public async getLoginInformation(): Promise<LoginInformation> {
-        const creds = await this.authenticationProvider.getBasicCredentials();
-        return {
-            server: DockerHubRequestUrl.toString(),
-            username: creds.username,
-            secret: creds.secret,
-        };
+    public async getLoginInformation(item: CommonRegistryItem): Promise<LoginInformation> {
+        return await this.authenticationProvider.getLoginInformation();
     }
 
     private async getNamespaces(): Promise<string[]> {

--- a/packages/vscode-docker-registries/src/clients/GenericRegistryV2/GenericRegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/GenericRegistryV2/GenericRegistryV2DataProvider.ts
@@ -116,7 +116,7 @@ export class GenericRegistryV2DataProvider extends RegistryV2DataProvider {
             throw new Error('Registry URL is invalid');
         }
 
-        const registryUriString = wizardContext.registryUri.toString();
+        const registryUriString = wizardContext.registryUri.toString().toLowerCase();
 
         // store registry url in memento
         const trackedRegistryStrings = this.extensionContext.globalState.get<string[]>(TrackedRegistriesKey, []);

--- a/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
@@ -10,10 +10,7 @@ import { AuthenticationProvider } from '../../contracts/AuthenticationProvider';
 import { LoginInformation } from '../../contracts/BasicCredentials';
 import { registryV2Request } from './registryV2Request';
 
-export interface V2RegistryItem extends CommonRegistryItem {
-    readonly baseUrl: vscode.Uri;
-}
-
+export type V2RegistryItem = CommonRegistryItem;
 export type V2RegistryRoot = CommonRegistryRoot;
 export type V2Registry = CommonRegistry & V2RegistryItem;
 export type V2Repository = CommonRepository & V2RegistryItem;


### PR DESCRIPTION
This PR makes `baseUrl` required on all registries object except `registryroot`, which then makes our model more extensible