### PR TITLE
Asynchronously fetch `createdAt` details

### DIFF
--- a/packages/vscode-docker-registries/src/clients/Common/models.ts
+++ b/packages/vscode-docker-registries/src/clients/Common/models.ts
@@ -46,7 +46,7 @@ export function isRepository(maybeRepository: unknown): maybeRepository is Commo
 export interface CommonTag extends CommonRegistryItem {
     readonly parent: CommonRepository;
     readonly type: 'commontag';
-    readonly createdAt?: Date;
+    createdAt?: Date;
     readonly baseUrl: vscode.Uri;
 }
 

--- a/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
@@ -75,7 +75,6 @@ export abstract class RegistryV2DataProvider extends CommonRegistryDataProvider 
                     label: tag,
                     type: 'commontag',
                     additionalContextValues: ['registryV2Tag'],
-                    createdAt: await this.getTagCreatedDate(repository, tag),
                 });
             }
 

--- a/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
@@ -70,9 +70,16 @@ export abstract class RegistryV2DataProvider extends CommonRegistryDataProvider 
                 label: tag,
                 type: 'commontag',
                 additionalContextValues: ['registryV2Tag'],
-                createdAt: await this.getTagDetails(repository, tag),
             });
         }
+
+        // Asynchronously begin getting the created date details for each tag
+        results.forEach(tag => {
+            this.getTagDetails(repository, tag.label).then((createdAt) => {
+                tag.createdAt = createdAt;
+                this.onDidChangeTreeDataEmitter.fire(tag);
+            }, () => { /* Best effort */ });
+        });
 
         return results;
     }

--- a/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
@@ -84,7 +84,7 @@ export abstract class RegistryV2DataProvider extends CommonRegistryDataProvider 
 
         // Asynchronously begin getting the created date details for each tag
         results.forEach(tag => {
-            this.getTagDetails(repository, tag.label).then((createdAt) => {
+            this.getTagCreatedDate(repository, tag.label).then((createdAt) => {
                 tag.createdAt = createdAt;
                 this.onDidChangeTreeDataEmitter.fire(tag);
             }, () => { /* Best effort */ });


### PR DESCRIPTION
This is incomplete. Still need to stop using `.map` within `getTags` / `getRepositories` in Github and Generic providers