### PR TITLE
Fix infinite loop when browsing registries with more than 100 repositories

### DIFF
--- a/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
@@ -37,6 +37,7 @@ export abstract class RegistryV2DataProvider extends CommonRegistryDataProvider 
                 authenticationProvider: this.getAuthenticationProvider(registry),
                 method: 'GET',
                 requestUri: nextLink,
+                query: Object.fromEntries(new URLSearchParams(nextLink.query)),
                 scopes: ['registry:catalog:*'],
             });
 


### PR DESCRIPTION
We saw an issue of the repository browser spinning indefinitely and many requests per second for /v2/_catalog on our local repository server. I traced it down to registryV2RequestInternal() being refactored recently to expect an options.query parameter. getNextLinkFromHeaders() returns a Uri object with existing query parameters for the next page of results, but since the query parameter was not being set registryV2RequestInternal() removed them, resulting in a loop retrieving the repository list.

There are a few ways to fix this. This PR is the absolute minimum to address this specific loop case. Another solution (with possible side-effects) might be to check for undefined and leave the query alone unless a query parameter is actually provided, like so:

```patch
diff --git a/packages/vscode-docker-registries/src/clients/RegistryV2/registryV2Request.ts b/packages/vscode-docker-registries/src/clients/RegistryV2/registryV2Request.ts
index 67893bb..33aac71 100644
--- a/packages/vscode-docker-registries/src/clients/RegistryV2/registryV2Request.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/registryV2Request.ts
@@ -45,8 +45,11 @@ export async function registryV2Request<T>(options: RegistryV2RequestOptions): P
 }

 async function registryV2RequestInternal<T>(options: RegistryV2RequestOptions): Promise<RegistryV2Response<T>> {
-    const query = new URLSearchParams(options.query);
-    const uri = options.requestUri.with({ query: query.toString() });
+    let uri = options.requestUri
+    if (options.query !== undefined) {
+        const query = new URLSearchParams(options.query);
+        uri = options.requestUri.with({ query: query.toString() });
+    }

     const request: RequestLike = {
         headers: {
```

Or a third option might be to remove the optional operator on the interface RegistryV2RequestOptions and update all cases where it is used to explicitly handle the new query parameter in some way. Let me know if one of these alternatives would be preferred and I'll close this and make another PR.