### PR TITLE
fix: Inspect Image Manifest 404

### DIFF
--- a/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/RegistryV2DataProvider.ts
@@ -162,7 +162,7 @@ export abstract class RegistryV2DataProvider extends CommonRegistryDataProvider 
             requestUri: requestUrl,
             scopes: [`repository:${item.parent.label}:pull`],
             headers: {
-                'accept': 'application/vnd.docker.distribution.manifest.v2+json'
+                'accept': 'application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.index.v1+json'
             }
         });
     }

--- a/packages/vscode-docker-registries/src/clients/RegistryV2/registryV2Request.ts
+++ b/packages/vscode-docker-registries/src/clients/RegistryV2/registryV2Request.ts
@@ -52,7 +52,7 @@ async function registryV2RequestInternal<T>(options: RegistryV2RequestOptions): 
 
     const request: RequestLike = {
         headers: {
-            accept: 'application/json',
+            accept: 'application/json,application/vnd.oci.image.index.v1+json',
             Authorization: `${auth.type} ${auth.accessToken}`,
             ...options.headers
         },


### PR DESCRIPTION
1) selected image tag: Inspect Image Manifest
2) Request to http://localhost:5000/v2/xxx/manifests/xxx failed with status 404: Not Found
