### PR TITLE
Support `profiles` and `services` arguments on more compose commands

### DIFF
--- a/packages/vscode-container-client/src/clients/DockerComposeClient/DockerComposeClient.ts
+++ b/packages/vscode-container-client/src/clients/DockerComposeClient/DockerComposeClient.ts
@@ -33,6 +33,7 @@ function withCommonOrchestratorArgs(options: CommonOrchestratorCommandOptions): 
         withNamedArg('--file', options.files),
         withNamedArg('--env-file', options.environmentFile),
         withNamedArg('--project-name', options.projectName),
+        withNamedArg('--profile', options.profiles),
     );
 }
 
@@ -90,7 +91,6 @@ export class DockerComposeClient extends ConfigurableClient implements IContaine
         return composeArgs(
             withComposeArg(this.composeV2),
             withCommonOrchestratorArgs(options),
-            withNamedArg('--profile', options.profiles),
             withArg('up'),
             withFlagArg('--detach', options.detached),
             withFlagArg('--build', options.build),
@@ -127,6 +127,7 @@ export class DockerComposeClient extends ConfigurableClient implements IContaine
             withFlagArg('--volumes', options.removeVolumes),
             withNamedArg('--timeout', options.timeoutSeconds?.toString(10)),
             withVerbatimArg(options.customOptions),
+            withArg(...(options.services || [])),
         )();
     }
 
@@ -151,6 +152,7 @@ export class DockerComposeClient extends ConfigurableClient implements IContaine
             withComposeArg(this.composeV2),
             withCommonOrchestratorArgs(options),
             withArg('start'),
+            withArg(...(options.services || [])),
         )();
     }
 
@@ -176,6 +178,7 @@ export class DockerComposeClient extends ConfigurableClient implements IContaine
             withCommonOrchestratorArgs(options),
             withArg('stop'),
             withNamedArg('--timeout', options.timeoutSeconds?.toString(10)),
+            withArg(...(options.services || [])),
         )();
     }
 
@@ -201,6 +204,7 @@ export class DockerComposeClient extends ConfigurableClient implements IContaine
             withCommonOrchestratorArgs(options),
             withArg('restart'),
             withNamedArg('--timeout', options.timeoutSeconds?.toString(10)),
+            withArg(...(options.services || [])),
         )();
     }
 
@@ -227,6 +231,7 @@ export class DockerComposeClient extends ConfigurableClient implements IContaine
             withArg('logs'),
             withFlagArg('--follow', options.follow),
             withNamedArg('--tail', options.tail?.toString(10)),
+            withArg(...(options.services || [])),
         )();
     }
 

--- a/packages/vscode-container-client/src/contracts/ContainerOrchestratorClient.ts
+++ b/packages/vscode-container-client/src/contracts/ContainerOrchestratorClient.ts
@@ -21,6 +21,10 @@ export type CommonOrchestratorCommandOptions = CommonCommandOptions & {
      * Project name
      */
     projectName?: string;
+    /**
+     * Specific service profiles to start/stop/etc.
+     */
+    profiles?: Array<string>;
 };
 
 // Up command types
@@ -45,10 +49,6 @@ export type UpCommandOptions = CommonOrchestratorCommandOptions & {
      * Specific services to start
      */
     services?: Array<string>;
-    /**
-     * Specific service profiles to start
-     */
-    profiles?: Array<string>;
     /**
      * Override specific service scaling
      */
@@ -82,6 +82,10 @@ export type DownCommandOptions = CommonOrchestratorCommandOptions & {
      */
     timeoutSeconds?: number;
     /**
+     * Specific services to stop
+     */
+    services?: Array<string>;
+    /**
      * Additional custom options to pass
      */
     customOptions?: string;
@@ -96,8 +100,12 @@ type DownCommand = {
 };
 
 // Start command types
-// No special options
-export type StartCommandOptions = CommonOrchestratorCommandOptions;
+export type StartCommandOptions = CommonOrchestratorCommandOptions & {
+    /**
+     * Specific services to start
+     */
+    services?: Array<string>;
+};
 
 type StartCommand = {
     /**
@@ -113,6 +121,10 @@ export type StopCommandOptions = CommonOrchestratorCommandOptions & {
      * A timeout in seconds
      */
     timeoutSeconds?: number;
+    /**
+     * Specific services to stop
+     */
+    services?: Array<string>;
 };
 
 type StopCommand = {
@@ -129,6 +141,10 @@ export type RestartCommandOptions = CommonOrchestratorCommandOptions & {
      * A timeout in seconds
      */
     timeoutSeconds?: number;
+    /**
+     * Specific services to restart
+     */
+    services?: Array<string>;
 };
 
 type RestartCommand = {
@@ -149,6 +165,10 @@ export type LogsCommandOptions = CommonOrchestratorCommandOptions & {
      * Maximum number of lines to show from the end of the logs
      */
     tail?: number;
+    /**
+     * Specific services to get logs for
+     */
+    services?: Array<string>;
 };
 
 type LogsCommand = {
@@ -160,7 +180,8 @@ type LogsCommand = {
 };
 
 // Config command types
-export type ConfigCommandOptions = CommonOrchestratorCommandOptions & {
+// The `--profile` argument works, but has rather confusing results when used with the config command. Best to not support it.
+export type ConfigCommandOptions = Omit<CommonOrchestratorCommandOptions, 'profiles'> & {
     configType: 'services' | 'images' | 'profiles' | 'volumes';
 };
 


### PR DESCRIPTION
Fixes #246. I found that `--profile` and `[SERVICE...]` are supported on all of our compose commands. I excluded the `docker compose config` command though from both because the results are confusing and it's hard to predict how it combines with the `--profiles` and `--services` arguments on `docker compose config`.