### PR TITLE
Fix the `vscode-jsonrpc` types requirement issue

### DIFF
--- a/packages/vscode-processutils/src/typings/CancellationTokenLike.ts
+++ b/packages/vscode-processutils/src/typings/CancellationTokenLike.ts
@@ -12,7 +12,10 @@ import { EventLike } from './EventLike';
  * (in the case of VSCode extensions), or `vscode-jsonrpc` (in the case of ServiceHub
  * workers in VS).
  */
-export type CancellationTokenLike = vscode.CancellationToken | jsonrpc.CancellationToken;
+export interface CancellationTokenLike {
+    isCancellationRequested: boolean;
+    onCancellationRequested: EventLike<void>;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CancellationTokenLike {
@@ -22,5 +25,5 @@ export namespace CancellationTokenLike {
     export const None: CancellationTokenLike = Object.freeze({
         isCancellationRequested: false,
         onCancellationRequested: EventLike.None,
-    });
+    }) satisfies vscode.CancellationToken & jsonrpc.CancellationToken; // The `satisfies` ensures that the type matches both vscode and vscode-jsonrpc `CancellationToken` interfaces
 }

--- a/packages/vscode-processutils/src/typings/DisposableLike.ts
+++ b/packages/vscode-processutils/src/typings/DisposableLike.ts
@@ -11,7 +11,9 @@ import type * as jsonrpc from 'vscode-jsonrpc';
  * (in the case of VSCode extensions), or `vscode-jsonrpc` (in the case of ServiceHub
  * workers in VS).
  */
-export type DisposableLike = vscode.Disposable | jsonrpc.Disposable;
+export interface DisposableLike {
+    dispose(): void;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace DisposableLike {
@@ -22,5 +24,5 @@ export namespace DisposableLike {
         dispose: () => {
             // Noop, not a real registration
         }
-    });
+    }) satisfies vscode.Disposable & jsonrpc.Disposable; // The `satisfies` ensures that the type matches both vscode and vscode-jsonrpc `Disposable` interfaces
 }

--- a/packages/vscode-processutils/src/typings/EventLike.ts
+++ b/packages/vscode-processutils/src/typings/EventLike.ts
@@ -12,7 +12,10 @@ import { DisposableLike } from './DisposableLike';
  * (in the case of VSCode extensions), or `vscode-jsonrpc` (in the case of ServiceHub
  * workers in VS).
  */
-export type EventLike<T> = vscode.Event<T> | jsonrpc.Event<T>;
+export interface EventLike<T> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (listener: (e: T) => any, thisArgs?: any, disposables?: DisposableLike[]): DisposableLike;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace EventLike {
@@ -21,5 +24,5 @@ export namespace EventLike {
      */
     export const None: EventLike<void> = Object.freeze(() => {
         return DisposableLike.None;
-    });
+    }) satisfies vscode.Event<void> & jsonrpc.Event<void>; // The `satisfies` ensures that the type matches both vscode and vscode-jsonrpc `Event` interfaces
 }


### PR DESCRIPTION
Fixes #256, while still ensuring that at the time of building this package, the `None`-objects we create must satisfy both the `vscode.Foo` and `vscode-jsonrpc.Foo` interfaces.