### PR TITLE
Add the `--watch` option to compose up

### DIFF
--- a/packages/vscode-container-client/src/clients/DockerComposeClientBase/DockerComposeClientBase.ts
+++ b/packages/vscode-container-client/src/clients/DockerComposeClientBase/DockerComposeClientBase.ts
@@ -104,6 +104,7 @@ export abstract class DockerComposeClientBase extends ConfigurableClient impleme
             withFlagArg('--no-recreate', options.recreate === 'no'),
             withFlagArg('--no-start', options.noStart),
             withFlagArg('--wait', options.wait),
+            withFlagArg('--watch', options.watch),
             withVerbatimArg(options.customOptions),
             withArg(...(options.services || [])),
         )();

--- a/packages/vscode-container-client/src/contracts/ContainerOrchestratorClient.ts
+++ b/packages/vscode-container-client/src/contracts/ContainerOrchestratorClient.ts
@@ -57,7 +57,8 @@ export type UpCommandOptions = CommonOrchestratorCommandOptions & {
      */
     build?: boolean;
     /**
-     * Whether to run in a detached session
+     * Whether to run in a detached session.
+     * Not compatible with `watch`.
      */
     detached?: boolean;
     /**
@@ -87,6 +88,11 @@ export type UpCommandOptions = CommonOrchestratorCommandOptions & {
      * If true, the containers will be created but not started
      */
     noStart?: boolean;
+    /**
+     * If true, the command will watch for changes in the files and automatically rebuild and restart services.
+     * Not compatible with `detached`.
+     */
+    watch?: boolean;
     /**
      * Additional custom options to pass
      */


### PR DESCRIPTION
Potentially needed for https://github.com/microsoft/vscode-containers/issues/87 (though we may not end up going this way). That said, it's trivial to add this flag arg.