### PR TITLE
Pass feedBaseUrl to NPM release template for internal feed publish

### DIFF
--- a/.config/release.yml
+++ b/.config/release.yml
@@ -51,3 +51,4 @@ extends:
     approverAliases: ${{ variables.npmReleaseApproverAliases }}
     gitHubServiceConnection: ${{ variables.gitHubServiceConnection }}
     releaseApprovalEnvironment: VSCodeDockerExtensionPublish
+    feedBaseUrl: ${{ variables.feedBaseUrl }}


### PR DESCRIPTION
Adds the `feedBaseUrl` parameter to the NPM release pipeline config so the released tarball is also published to the internal Azure Artifacts feed (after the ESRP publish to npmjs.org).

In `.config/release.yml`, passes `feedBaseUrl: ${{ variables.feedBaseUrl }}` to the `azdo-pipelines/1es-mb-release-npm.yml@azExtTemplates` template. `feedBaseUrl` is already provided by the shared `azdo-pipelines/azcode.variables.yml@azExtTemplates` template, so no other change is needed.

This pairs with a companion change in microsoft/vscode-azuretools that makes the NPM release template also publish to the internal feed.

⚠️ **Must stay a DRAFT** until the vscode-azuretools template change is released to `azext-pt/v1`. This repo consumes the template at `ref: azext-pt/v1`, which does not yet have the `feedBaseUrl` parameter. Merging before the template is released would cause the pipeline to fail to compile on the unknown parameter.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>