### PR TITLE
Update which to v7 and bump vscode-processutils to 0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4588,11 +4588,11 @@
         },
         "packages/vscode-processutils": {
             "name": "@microsoft/vscode-processutils",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "tree-kill": "^1.2.2",
-                "which": "^5.0.0"
+                "which": "^7.0.0"
             },
             "devDependencies": {
                 "@types/which": "^3.0.4",
@@ -4600,27 +4600,27 @@
             }
         },
         "packages/vscode-processutils/node_modules/isexe": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
             "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "packages/vscode-processutils/node_modules/which": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
+            "integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
             "license": "ISC",
             "dependencies": {
-                "isexe": "^3.1.1"
+                "isexe": "^4.0.0"
             },
             "bin": {
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         }
     }

--- a/packages/vscode-processutils/CHANGELOG.md
+++ b/packages/vscode-processutils/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3 - 19 June 2026
+### Changed
+* Updated `which` to v7.
+
 ## 0.2.2 - 22 April 2026
 ### Changed
 * Removed runtime imports of `'vscode'`. [#358](https://github.com/microsoft/vscode-docker-extensibility/pull/358)

--- a/packages/vscode-processutils/package.json
+++ b/packages/vscode-processutils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-processutils",
     "author": "Microsoft Corporation",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Library support for building command lines and running external processes, primarily for use in VS Code.",
     "license": "See LICENSE in the project root for license information.",
     "repository": {
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "tree-kill": "^1.2.2",
-        "which": "^5.0.0"
+        "which": "^7.0.0"
     },
     "devDependencies": {
         "@types/which": "^3.0.4",


### PR DESCRIPTION
## Summary
- Updated `which` from `^5.0.0` to `^7.0.0` in `@microsoft/vscode-processutils`.
- Bumped the package version to `0.2.3` and added a CHANGELOG entry.

## Notes
- `which@7` ships no bundled type declarations (the tarball contains only JS), so `@types/which` is retained.
- The `which.sync(...)` API is unchanged across v5→v7; the majors were purely Node engine-range bumps.
- `which@7` requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. VS Code targets Node 24.15, which satisfies this.

## Validation
- ✅ Build, lint, and tests pass for `vscode-processutils`.