### PR TITLE
Add Wslc client support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -87,7 +87,8 @@
             "description": "Select the container runtime to use for integration tests",
             "options": [
                 "docker",
-                "podman"
+                "podman",
+                "wslc"
             ],
             "default": "docker"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4539,7 +4539,7 @@
         },
         "packages/vscode-container-client": {
             "name": "@microsoft/vscode-container-client",
-            "version": "0.5.4",
+            "version": "0.6.0",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "@microsoft/vscode-processutils": "^0.2.2",

--- a/packages/vscode-container-client/CHANGELOG.md
+++ b/packages/vscode-container-client/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0 - TBD
+### Added
+* Added `WslcClient` for the Windows Subsystem for Linux Container (`wslc`) CLI as an alternative container runtime. Windows-only.
+
+### Fixed
+* `execContainer` now emits `--detach` instead of `--detached` when `detached: true` is passed.
+
 ## 0.5.4 - 22 April 2026
 ### Changed
 * Removed runtime imports of `'vscode'`. [#359](https://github.com/microsoft/vscode-docker-extensibility/pull/359)

--- a/packages/vscode-container-client/package.json
+++ b/packages/vscode-container-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-container-client",
     "author": "Microsoft Corporation",
-    "version": "0.5.4",
+    "version": "0.6.0",
     "description": "Extensibility model for implementing container runtime providers (shared by VS and VS Code)",
     "license": "See LICENSE in the project root for license information.",
     "repository": {

--- a/packages/vscode-container-client/src/clients/DockerClientBase/DockerClientBase.ts
+++ b/packages/vscode-container-client/src/clients/DockerClientBase/DockerClientBase.ts
@@ -674,7 +674,7 @@ export abstract class DockerClientBase extends ConfigurableClient implements ICo
             withNamedArg('--network', options.network),
             withNamedArg('--network-alias', options.networkAlias),
             withDockerAddHostArg(options.addHost),
-            withDockerMountsArg(options.mounts),
+            this.getRunContainerMountsArg(options.mounts),
             withDockerLabelsArg(options.labels),
             withDockerEnvArg(options.environmentVariables),
             withNamedArg('--env-file', options.environmentFiles),
@@ -685,6 +685,16 @@ export abstract class DockerClientBase extends ConfigurableClient implements ICo
             withArg(options.imageRef),
             typeof options.command === 'string' ? withVerbatimArg(options.command) : withArg(...(toArray(options.command ?? []))),
         )();
+    }
+
+    /**
+     * Build the mount-related arguments for {@link getRunContainerCommandArgs}.
+     * Docker-like clients use `--mount type=...,source=...,destination=...[,readonly]`.
+     * Subclasses can override this to emit a different flag (e.g. `--volume`) for
+     * runtimes that don't support `--mount`.
+     */
+    protected getRunContainerMountsArg(mounts: RunContainerCommandOptions['mounts']) {
+        return withDockerMountsArg(mounts);
     }
 
     /**
@@ -723,7 +733,7 @@ export abstract class DockerClientBase extends ConfigurableClient implements ICo
         return composeArgs(
             withArg('container', 'exec'),
             withFlagArg('--interactive', options.interactive),
-            withFlagArg('--detached', options.detached),
+            withFlagArg('--detach', options.detached),
             withFlagArg('--tty', options.tty),
             withDockerEnvArg(options.environmentVariables),
             withArg(options.container),

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcClient.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcClient.ts
@@ -1,0 +1,739 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    CommandLineArgs,
+    composeArgs,
+    withArg,
+    withFlagArg,
+    withNamedArg,
+    withQuotedArg,
+    withVerbatimArg,
+} from '@microsoft/vscode-processutils';
+import { GeneratorCommandResponse, PromiseCommandResponse } from '../../contracts/CommandRunner';
+import {
+    BuildImageCommandOptions,
+    CheckInstallCommandOptions,
+    CreateNetworkCommandOptions,
+    EventItem,
+    EventStreamCommandOptions,
+    InfoCommandOptions,
+    InfoItem,
+    InspectContainersCommandOptions,
+    InspectContainersItem,
+    InspectImagesCommandOptions,
+    InspectImagesItem,
+    InspectNetworksCommandOptions,
+    InspectNetworksItem,
+    InspectVolumesCommandOptions,
+    InspectVolumesItem,
+    ListContainersCommandOptions,
+    ListContainersItem,
+    ListImagesCommandOptions,
+    ListImagesItem,
+    ListNetworkItem,
+    ListNetworksCommandOptions,
+    ListVolumeItem,
+    ListVolumesCommandOptions,
+    PortBinding,
+    PruneContainersCommandOptions,
+    PruneImagesCommandOptions,
+    PruneNetworksCommandOptions,
+    PruneNetworksItem,
+    PruneVolumesCommandOptions,
+    PruneVolumesItem,
+    PullImageCommandOptions,
+    ReadFileCommandOptions,
+    RemoveContainersCommandOptions,
+    RemoveImagesCommandOptions,
+    RemoveNetworksCommandOptions,
+    RestartContainersCommandOptions,
+    RunContainerCommandOptions,
+    VersionCommandOptions,
+    VersionItem,
+    WriteFileCommandOptions,
+} from '../../contracts/ContainerClient';
+import { asIds } from '../../utils/asIds';
+import { CommandNotSupportedError } from '../../utils/CommandNotSupportedError';
+import { dayjs } from '../../utils/dayjs';
+import { parseDockerLikeImageName } from '../../utils/parseDockerLikeImageName';
+import { DockerClientBase } from '../DockerClientBase/DockerClientBase';
+import { parsePruneLikeOutput } from '../DockerClientBase/parsePruneLikeOutput';
+import { withDockerBuildArg } from '../DockerClientBase/withDockerBuildArg';
+import { withDockerEnvArg } from '../DockerClientBase/withDockerEnvArg';
+import { withDockerBooleanFilterArg, withDockerFilterArg } from '../DockerClientBase/withDockerFilterArg';
+import { withDockerLabelFilterArgs } from '../DockerClientBase/withDockerLabelFilterArgs';
+import { withDockerLabelsArg } from '../DockerClientBase/withDockerLabelsArg';
+import { withDockerPortsArg } from '../DockerClientBase/withDockerPortsArg';
+import { withContainerPathArg } from '../DockerClientBase/withContainerPathArg';
+import { WslcInspectContainerRecordSchema, normalizeWslcInspectContainerRecord } from './WslcInspectContainerRecord';
+import { WslcInspectImageRecordSchema, normalizeWslcInspectImageRecord } from './WslcInspectImageRecord';
+import { WslcInspectVolumeRecordSchema, normalizeWslcInspectVolumeRecord } from './WslcInspectVolumeRecord';
+import { mapWslcContainerState, WslcListContainerRecordSchema } from './WslcListContainerRecord';
+import { WslcListImageRecordSchema } from './WslcListImageRecord';
+import { normalizeWslcListVolumeRecord, WslcListVolumeRecordSchema } from './WslcListVolumeRecord';
+import { normalizeWslcInspectNetworkRecord, normalizeWslcListNetworkRecord, WslcNetworkRecordSchema } from './WslcNetworkRecord';
+
+/**
+ * wslc reports pruned resources as `Deleted: <name>` lines, unlike the Docker CLI
+ * which prints bare names (volumes) or a `Deleted Networks:` header (networks).
+ */
+const WslcPruneDeletedRegex = /^Deleted:\s+(.+?)\s*$/igm;
+
+/**
+ * {@link WslcClient} implements {@link IContainersClient} for the Windows Subsystem for Linux
+ * Container CLI (`wslc`). It is mostly compatible with the Docker CLI surface, so it inherits
+ * from {@link DockerClientBase} and overrides only the arg builders / parsers that differ.
+ *
+ * Key differences vs. Docker:
+ * - The CLI is only available on Windows.
+ * - `--format` accepts only `json` or `table` (no Go templates).
+ * - List verb is `list` for containers and `images` for images.
+ * - Image removal uses `rmi`, container removal uses `remove`.
+ * - `inspect` uses the top-level `inspect --type <container|image|volume|network>` form (JSON by
+ *   default, no `--format`); it accepts multiple ids and exits non-zero if any are missing.
+ * - There are no `info`, `events`, or `context` subcommands.
+ * - File reads use `container exec tar` (wslc can't stream `cp` to stdout) and writes use
+ *   `container cp` (there is no top-level `cp`). Reads require `tar` in the container image.
+ */
+export class WslcClient extends DockerClientBase {
+    /**
+     * The ID of the WSLC client.
+     */
+    public static ClientId = 'com.microsoft.visualstudio.containers.wslc';
+
+    /**
+     * The default `--format` argument value. `wslc` only accepts the literal
+     * tokens `json` or `table`, not Go templates.
+     */
+    protected readonly defaultFormatForJson: string = 'json';
+
+    public constructor(
+        commandName: string = 'wslc',
+        displayName: string = 'WSLC',
+        description: string = 'Runs container commands using the Windows Subsystem for Linux Container CLI'
+    ) {
+        super(
+            WslcClient.ClientId,
+            commandName,
+            displayName,
+            description
+        );
+    }
+
+    //#region Information Commands
+
+    // wslc has no `info` subcommand. WSL containers are always Linux, so return a synthetic
+    // record so callers depending on `osType` keep working without throwing.
+    protected override getInfoCommandArgs(options: InfoCommandOptions): CommandLineArgs {
+        return composeArgs(withArg('version'))();
+    }
+
+    protected override parseInfoCommandOutput(output: string, strict: boolean): Promise<InfoItem> {
+        return Promise.resolve({
+            operatingSystem: undefined,
+            osType: 'linux',
+            raw: output,
+        });
+    }
+
+    // wslc emits plain text like `wslc <version>` and does not support `--format`.
+    protected override getVersionCommandArgs(options: VersionCommandOptions): CommandLineArgs {
+        return composeArgs(withArg('version'))();
+    }
+
+    protected override parseVersionCommandOutput(output: string, strict: boolean): Promise<VersionItem> {
+        const match = /(\d+(?:\.\d+)+)/.exec(output);
+        if (!match && strict) {
+            throw new Error(`Unable to parse wslc version output: ${output}`);
+        }
+        const version = match?.[1] ?? '';
+
+        return Promise.resolve({
+            client: version,
+            server: undefined,
+        });
+    }
+
+    protected override getCheckInstallCommandArgs(options: CheckInstallCommandOptions): CommandLineArgs {
+        return composeArgs(withArg('--version'))();
+    }
+
+    // wslc has no `events` subcommand.
+    public override getEventStream(options: EventStreamCommandOptions): Promise<GeneratorCommandResponse<EventItem>> {
+        return Promise.reject(new CommandNotSupportedError('wslc does not support the events command.'));
+    }
+
+    //#endregion
+
+    //#region Image Commands
+
+    protected override getBuildImageCommandArgs(options: BuildImageCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('build'),
+            withFlagArg('--pull', options.pull),
+            withNamedArg('--file', options.file),
+            withNamedArg('--target', options.stage),
+            withNamedArg('--tag', options.tags),
+            withDockerLabelsArg(options.labels),
+            withDockerBuildArg(options.args),
+            withVerbatimArg(options.customOptions),
+            withQuotedArg(options.path),
+        )();
+    }
+
+    protected override getListImagesCommandArgs(options: ListImagesCommandOptions): CommandLineArgs {
+        // wslc `images` has no `--all` flag, but it does support --filter (dangling / reference /
+        // label, same syntax as Docker) and only `json` as a format value.
+        return composeArgs(
+            withArg('images'),
+            withDockerBooleanFilterArg('dangling', options.dangling),
+            withDockerFilterArg(options.references?.map((reference) => `reference=${reference}`)),
+            withDockerLabelFilterArgs(options.labels),
+            withNamedArg('--format', this.defaultFormatForJson),
+        )();
+    }
+
+    protected override parseListImagesCommandOutput(
+        options: ListImagesCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<Array<ListImagesItem>> {
+        const images = new Array<ListImagesItem>();
+        try {
+            const parsed: unknown = JSON.parse(output);
+            const rawArray: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+            for (const raw of rawArray) {
+                try {
+                    // Validate per-record so one malformed entry doesn't discard the whole list.
+                    const rawImage = WslcListImageRecordSchema.parse(raw);
+                    const repositoryAndTag = rawImage.Repository
+                        ? `${rawImage.Repository}${rawImage.Tag ? `:${rawImage.Tag}` : ''}`
+                        : undefined;
+                    images.push({
+                        id: rawImage.Id,
+                        image: parseDockerLikeImageName(repositoryAndTag),
+                        createdAt: dayjs.unix(rawImage.Created).toDate(),
+                        size: rawImage.Size,
+                    });
+                } catch (err) {
+                    if (strict) {
+                        throw err;
+                    }
+                }
+            }
+        } catch (err) {
+            if (strict) {
+                throw err;
+            }
+        }
+
+        return Promise.resolve(images);
+    }
+
+    protected override getRemoveImagesCommandArgs(options: RemoveImagesCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('rmi'),
+            withFlagArg('--force', options.force),
+            withArg(...options.imageRefs),
+        )();
+    }
+
+    // wslc `pull` only accepts the image ref; it has no --all-tags or
+    // --disable-content-trust flags.
+    protected override getPullImageCommandArgs(options: PullImageCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('pull'),
+            withArg(options.imageRef),
+        )();
+    }
+
+    // wslc `image prune` accepts `--all` but not `--force` (it never prompts).
+    protected override getPruneImagesCommandArgs(options: PruneImagesCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('image', 'prune'),
+            withFlagArg('--all', options.all),
+        )();
+    }
+
+    protected override parseRemoveImagesCommandOutput(
+        options: RemoveImagesCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<Array<string>> {
+        // wslc `rmi` prints the removed image id per line (no `deleted:` prefix).
+        return Promise.resolve(asIds(output));
+    }
+
+    protected override getInspectImagesCommandArgs(options: InspectImagesCommandOptions): CommandLineArgs {
+        // wslc `inspect --type image` accepts multiple ids and returns a JSON array. If any id is
+        // missing it exits non-zero (the runner surfaces that as an error), so no id is silently lost.
+        return composeArgs(
+            withArg('inspect'),
+            withNamedArg('--type', 'image'),
+            withArg(...options.imageRefs),
+        )();
+    }
+
+    protected override parseInspectImagesCommandOutput(
+        options: InspectImagesCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<Array<InspectImagesItem>> {
+        const items: InspectImagesItem[] = [];
+        const trimmed = output.trim();
+        if (!trimmed) {
+            return Promise.resolve(items);
+        }
+        try {
+            const parsed: unknown = JSON.parse(trimmed);
+            const rawArray: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+            for (const raw of rawArray) {
+                try {
+                    // Validate per-record so one malformed entry doesn't discard the whole result.
+                    const record = WslcInspectImageRecordSchema.parse(raw);
+                    items.push(normalizeWslcInspectImageRecord(record, trimmed));
+                } catch (err) {
+                    if (strict) { throw err; }
+                }
+            }
+        } catch (err) {
+            if (strict) { throw err; }
+        }
+        return Promise.resolve(items);
+    }
+
+    //#endregion
+
+    //#region Container Commands
+
+    protected override getListContainersCommandArgs(options: ListContainersCommandOptions): CommandLineArgs {
+        // wslc `list` supports --all, --filter (same keys/format as Docker), and --format json.
+        // Emit the same filters the base does so consumers that rely on server-side filtering
+        // (e.g. "containers using this volume/network/image") get correct results.
+        return composeArgs(
+            withArg('list'),
+            withFlagArg('--all', options.all),
+            withDockerLabelFilterArgs(options.labels),
+            withDockerFilterArg(options.running ? 'status=running' : undefined),
+            withDockerFilterArg(options.exited ? 'status=exited' : undefined),
+            withDockerFilterArg(options.names?.map((name) => `name=${name}`)),
+            withDockerFilterArg(options.imageAncestors?.map((id) => `ancestor=${id}`)),
+            withDockerFilterArg(options.volumes?.map((volume) => `volume=${volume}`)),
+            withDockerFilterArg(options.networks?.map((network) => `network=${network}`)),
+            withNamedArg('--format', this.defaultFormatForJson),
+        )();
+    }
+
+    protected override parseListContainersCommandOutput(
+        options: ListContainersCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<Array<ListContainersItem>> {
+        const containers = new Array<ListContainersItem>();
+        try {
+            const parsed: unknown = JSON.parse(output);
+            const rawArray: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+            for (const raw of rawArray) {
+                try {
+                    // Validate per-record so one malformed entry doesn't discard the whole list.
+                    const rawContainer = WslcListContainerRecordSchema.parse(raw);
+                    const state = mapWslcContainerState(rawContainer.State);
+                    const ports: PortBinding[] = (rawContainer.Ports ?? []).map(p => ({
+                        containerPort: p.ContainerPort ?? 0,
+                        hostIp: p.HostIp || '127.0.0.1',
+                        hostPort: p.HostPort,
+                        protocol: p.Protocol?.toLowerCase() === 'tcp'
+                            ? 'tcp'
+                            : p.Protocol?.toLowerCase() === 'udp'
+                                ? 'udp'
+                                : undefined,
+                    }));
+
+                    containers.push({
+                        id: rawContainer.Id,
+                        name: rawContainer.Name ?? '',
+                        image: parseDockerLikeImageName(rawContainer.Image),
+                        labels: rawContainer.Labels ?? {},
+                        createdAt: dayjs.unix(rawContainer.CreatedAt).toDate(),
+                        ports,
+                        networks: rawContainer.Networks ?? [],
+                        state,
+                        status: undefined,
+                    });
+                } catch (err) {
+                    if (strict) {
+                        throw err;
+                    }
+                }
+            }
+        } catch (err) {
+            if (strict) {
+                throw err;
+            }
+        }
+
+        return Promise.resolve(containers);
+    }
+
+    protected override getRemoveContainersCommandArgs(options: RemoveContainersCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('remove'),
+            withFlagArg('--force', options.force),
+            withArg(...options.containers),
+        )();
+    }
+
+    /**
+     * wslc does not support the Docker `--mount` flag; emit the legacy
+     * `--volume src:dst[:ro]` form instead. This works for both bind mounts
+     * (source is a host path) and named-volume mounts (source is a volume name).
+     */
+    protected override getRunContainerMountsArg(mounts: RunContainerCommandOptions['mounts']) {
+        return withNamedArg(
+            '--volume',
+            (mounts ?? []).map(m => `${m.source}:${m.destination}${m.readOnly ? ':ro' : ''}`),
+        );
+    }
+
+    // wslc `run` supports `--network-alias` but not `--add-host`, `--expose`, or `--platform`.
+    // Throw if a caller sets an unsupported option so behavior is explicit rather than silently
+    // dropping the value. Drop them only when unset (the common runtime-agnostic case).
+    protected override getRunContainerCommandArgs(options: RunContainerCommandOptions): CommandLineArgs {
+        if (options.addHost && options.addHost.length > 0) {
+            throw new CommandNotSupportedError('wslc run does not support --add-host.');
+        }
+        if (options.exposePorts && options.exposePorts.length > 0) {
+            throw new CommandNotSupportedError('wslc run does not support --expose.');
+        }
+        if (options.platform) {
+            throw new CommandNotSupportedError('wslc run does not support --platform.');
+        }
+        return composeArgs(
+            withArg('run'),
+            withFlagArg('--detach', options.detached),
+            withFlagArg('--interactive', options.interactive),
+            withFlagArg('--tty', options.detached || options.interactive),
+            withFlagArg('--rm', options.removeOnExit),
+            withNamedArg('--name', options.name),
+            withDockerPortsArg(options.ports),
+            withFlagArg('--publish-all', options.publishAllPorts),
+            withNamedArg('--network', options.network),
+            withNamedArg('--network-alias', options.networkAlias),
+            this.getRunContainerMountsArg(options.mounts),
+            withDockerLabelsArg(options.labels),
+            withDockerEnvArg(options.environmentVariables),
+            withNamedArg('--env-file', options.environmentFiles),
+            withNamedArg('--entrypoint', options.entrypoint),
+            withVerbatimArg(options.customOptions),
+            withArg(options.imageRef),
+            typeof options.command === 'string'
+                ? withVerbatimArg(options.command)
+                : withArg(...(options.command ?? [])),
+        )();
+    }
+
+    // wslc `container prune` does not accept --force or --filter. The contract today
+    // has no filterable options to validate, so just emit the bare verb.
+    protected override getPruneContainersCommandArgs(options: PruneContainersCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('container', 'prune'),
+        )();
+    }
+
+    // wslc has no `restart` subcommand. Reject rather than silently inheriting
+    // a command line that wslc would reject.
+    public override restartContainers(options: RestartContainersCommandOptions): Promise<PromiseCommandResponse<Array<string>>> {
+        return Promise.reject(new CommandNotSupportedError('wslc does not support the restart command.'));
+    }
+
+    protected override getInspectContainersCommandArgs(options: InspectContainersCommandOptions): CommandLineArgs {
+        // wslc `inspect --type container` accepts multiple ids and returns a JSON array; a missing
+        // id makes it exit non-zero (surfaced as an error) rather than being silently dropped.
+        return composeArgs(
+            withArg('inspect'),
+            withNamedArg('--type', 'container'),
+            withArg(...options.containers),
+        )();
+    }
+
+    protected override parseInspectContainersCommandOutput(
+        options: InspectContainersCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<Array<InspectContainersItem>> {
+        const items: InspectContainersItem[] = [];
+        const trimmed = output.trim();
+        if (!trimmed) {
+            return Promise.resolve(items);
+        }
+        try {
+            const parsed: unknown = JSON.parse(trimmed);
+            const rawArray: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+            for (const raw of rawArray) {
+                try {
+                    // Validate per-record so one malformed entry doesn't discard the whole result.
+                    const record = WslcInspectContainerRecordSchema.parse(raw);
+                    items.push(normalizeWslcInspectContainerRecord(record, trimmed));
+                } catch (err) {
+                    if (strict) { throw err; }
+                }
+            }
+        } catch (err) {
+            if (strict) { throw err; }
+        }
+        return Promise.resolve(items);
+    }
+
+    //#endregion
+
+    //#region Volume Commands
+
+    protected override getListVolumesCommandArgs(options: ListVolumesCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('volume', 'list'),
+            withNamedArg('--format', this.defaultFormatForJson),
+        )();
+    }
+
+    protected override parseListVolumesCommandOutput(
+        options: ListVolumesCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<ListVolumeItem[]> {
+        const items: ListVolumeItem[] = [];
+        const trimmed = output.trim();
+        if (trimmed) {
+            try {
+                const parsed: unknown = JSON.parse(trimmed);
+                const rawArray: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+                for (const raw of rawArray) {
+                    try {
+                        // Validate per-record so one malformed entry doesn't discard the whole list.
+                        const record = WslcListVolumeRecordSchema.parse(raw);
+                        items.push(normalizeWslcListVolumeRecord(record));
+                    } catch (err) {
+                        if (strict) { throw err; }
+                    }
+                }
+            } catch (err) {
+                if (strict) { throw err; }
+            }
+        }
+        return Promise.resolve(items);
+    }
+
+    protected override getInspectVolumesCommandArgs(options: InspectVolumesCommandOptions): CommandLineArgs {
+        // wslc `inspect --type volume` accepts multiple names and returns a JSON array; a missing
+        // name makes it exit non-zero (surfaced as an error) rather than being silently dropped.
+        return composeArgs(
+            withArg('inspect'),
+            withNamedArg('--type', 'volume'),
+            withArg(...options.volumes),
+        )();
+    }
+
+    protected override parseInspectVolumesCommandOutput(
+        options: InspectVolumesCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<Array<InspectVolumesItem>> {
+        const items: InspectVolumesItem[] = [];
+        const trimmed = output.trim();
+        if (!trimmed) {
+            return Promise.resolve(items);
+        }
+        try {
+            const parsed: unknown = JSON.parse(trimmed);
+            const rawArray: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+            for (const raw of rawArray) {
+                try {
+                    // Validate per-record so one malformed entry doesn't discard the whole result.
+                    const record = WslcInspectVolumeRecordSchema.parse(raw);
+                    items.push(normalizeWslcInspectVolumeRecord(record, trimmed));
+                } catch (err) {
+                    if (strict) { throw err; }
+                }
+            }
+        } catch (err) {
+            if (strict) { throw err; }
+        }
+        return Promise.resolve(items);
+    }
+
+    // wslc `volume prune` accepts `--all` / `--filter` but not `--force`. The contract
+    // exposes no options today, so emit the bare verb. Deleted names are reported as
+    // `Deleted: <name>` lines (not the Docker bare-name format).
+    protected override getPruneVolumesCommandArgs(options: PruneVolumesCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('volume', 'prune'),
+        )();
+    }
+
+    protected override parsePruneVolumesCommandOutput(
+        options: PruneVolumesCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<PruneVolumesItem> {
+        const pruned = parsePruneLikeOutput(output, { resourceRegex: WslcPruneDeletedRegex });
+        return Promise.resolve({
+            volumesDeleted: pruned.resources,
+            spaceReclaimed: pruned.spaceReclaimed,
+        });
+    }
+
+    //#endregion
+
+    //#region Network Commands
+
+    // wslc network supports create / list / remove / inspect / prune. Inspect uses the
+    // top-level `inspect --type network` form (same as other object types in wslc).
+
+    protected override getCreateNetworkCommandArgs(options: CreateNetworkCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('network', 'create'),
+            withNamedArg('--driver', options.driver),
+            withArg(options.name),
+        )();
+    }
+
+    protected override getListNetworksCommandArgs(options: ListNetworksCommandOptions): CommandLineArgs {
+        // wslc network list has no filter flags; any `labels`/`driver` filters on
+        // ListNetworksCommandOptions are silently ignored.
+        return composeArgs(
+            withArg('network', 'list'),
+            withNamedArg('--format', this.defaultFormatForJson),
+        )();
+    }
+
+    protected override parseListNetworksCommandOutput(
+        options: ListNetworksCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<Array<ListNetworkItem>> {
+        const items: ListNetworkItem[] = [];
+        const trimmed = output.trim();
+        if (!trimmed) {
+            return Promise.resolve(items);
+        }
+        try {
+            const parsed: unknown = JSON.parse(trimmed);
+            const rawArray: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+            for (const raw of rawArray) {
+                try {
+                    // Validate per-record so one malformed entry doesn't discard the whole list.
+                    const record = WslcNetworkRecordSchema.parse(raw);
+                    items.push(normalizeWslcListNetworkRecord(record));
+                } catch (err) {
+                    if (strict) { throw err; }
+                }
+            }
+        } catch (err) {
+            if (strict) { throw err; }
+        }
+        return Promise.resolve(items);
+    }
+
+    protected override getRemoveNetworksCommandArgs(options: RemoveNetworksCommandOptions): CommandLineArgs {
+        // wslc network remove takes positional names and supports --force.
+        return composeArgs(
+            withArg('network', 'remove'),
+            withFlagArg('--force', options.force),
+            withArg(...options.networks),
+        )();
+    }
+
+    protected override getInspectNetworksCommandArgs(options: InspectNetworksCommandOptions): CommandLineArgs {
+        // wslc `inspect --type network` accepts multiple names and returns a JSON array; a missing
+        // name makes it exit non-zero (surfaced as an error) rather than being silently dropped.
+        return composeArgs(
+            withArg('inspect'),
+            withNamedArg('--type', 'network'),
+            withArg(...options.networks),
+        )();
+    }
+
+    protected override parseInspectNetworksCommandOutput(
+        options: InspectNetworksCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<Array<InspectNetworksItem>> {
+        const items: InspectNetworksItem[] = [];
+        const trimmed = output.trim();
+        if (!trimmed) {
+            return Promise.resolve(items);
+        }
+        try {
+            const parsed: unknown = JSON.parse(trimmed);
+            const rawArray: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+            for (const raw of rawArray) {
+                try {
+                    // Validate per-record so one malformed entry doesn't discard the whole result.
+                    const record = WslcNetworkRecordSchema.parse(raw);
+                    items.push(normalizeWslcInspectNetworkRecord(record, trimmed));
+                } catch (err) {
+                    if (strict) { throw err; }
+                }
+            }
+        } catch (err) {
+            if (strict) { throw err; }
+        }
+        return Promise.resolve(items);
+    }
+
+    // wslc `network prune` accepts `--filter` but not `--force`. The contract exposes no
+    // options today, so emit the bare verb. Deleted names are reported as `Deleted: <name>`
+    // lines (not the Docker "Deleted Networks:" header format).
+    protected override getPruneNetworksCommandArgs(options: PruneNetworksCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('network', 'prune'),
+        )();
+    }
+
+    protected override parsePruneNetworksCommandOutput(
+        options: PruneNetworksCommandOptions,
+        output: string,
+        strict: boolean,
+    ): Promise<PruneNetworksItem> {
+        const pruned = parsePruneLikeOutput(output, { resourceRegex: WslcPruneDeletedRegex });
+        return Promise.resolve({
+            networksDeleted: pruned.resources,
+        });
+    }
+
+    //#endregion
+
+    //#region File Commands
+
+    // wslc has no top-level `cp`, and `container cp` cannot stream a container path to stdout.
+    // Read the file by tarring it inside the container via `exec` so the caller can untar the
+    // single-entry stream (matching the tar that Docker's `cp <path> -` produces). This requires
+    // `tar` to be available in the container image. wslc only runs Linux containers.
+    protected override getReadFileCommandArgs(options: ReadFileCommandOptions): CommandLineArgs {
+        const containerPath = options.path.replace(/\/+$/, '');
+        const lastSlash = containerPath.lastIndexOf('/');
+        const directory = lastSlash <= 0 ? '/' : containerPath.slice(0, lastSlash);
+        const fileName = containerPath.slice(lastSlash + 1);
+
+        return this.getExecContainerCommandArgs({
+            container: options.container,
+            command: ['tar', '-cf', '-', '-C', directory, fileName],
+        });
+    }
+
+    // wslc uses `container cp` (there is no top-level `cp`). `container cp - CONTAINER:DIR`
+    // extracts a tar archive from stdin into the destination directory (Docker-compatible), which
+    // matches the tar stream the caller pipes in for writes.
+    protected override getWriteFileCommandArgs(options: WriteFileCommandOptions): CommandLineArgs {
+        return composeArgs(
+            withArg('container', 'cp'),
+            withArg(options.inputFile || '-'),
+            withContainerPathArg(options),
+        )();
+    }
+
+    //#endregion
+}
+

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcInspectContainerRecord.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcInspectContainerRecord.ts
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { toArray } from '@microsoft/vscode-processutils';
+import * as z from 'zod/mini';
+import {
+    InspectContainersItem,
+    InspectContainersItemBindMount,
+    InspectContainersItemMount,
+    InspectContainersItemNetwork,
+    InspectContainersItemVolumeMount,
+    PortBinding,
+} from '../../contracts/ContainerClient';
+import { dayjs } from '../../utils/dayjs';
+import { parseDockerLikeImageName } from '../../utils/parseDockerLikeImageName';
+import { normalizeIpAddress } from '../DockerClientBase/normalizeIpAddress';
+import { parseDockerLikeEnvironmentVariables } from '../DockerClientBase/parseDockerLikeEnvironmentVariables';
+
+const WslcInspectBindMountSchema = z.object({
+    Type: z.literal('bind'),
+    Source: z.string(),
+    Destination: z.string(),
+    ReadWrite: z.optional(z.boolean()),
+});
+
+const WslcInspectVolumeMountSchema = z.object({
+    Type: z.literal('volume'),
+    Name: z.optional(z.string()),
+    Source: z.optional(z.string()),
+    Destination: z.string(),
+    Driver: z.optional(z.string()),
+    ReadWrite: z.optional(z.boolean()),
+});
+
+const WslcInspectMountSchema = z.union([
+    WslcInspectBindMountSchema,
+    WslcInspectVolumeMountSchema,
+]);
+
+const WslcInspectNetworkSchema = z.object({
+    Gateway: z.optional(z.string()),
+    IPAddress: z.optional(z.string()),
+    IPPrefixLen: z.optional(z.number()),
+    MacAddress: z.optional(z.string()),
+});
+
+const WslcInspectPortHostSchema = z.object({
+    HostIp: z.optional(z.string()),
+    HostPort: z.optional(z.string()),
+});
+
+const WslcInspectConfigSchema = z.object({
+    Image: z.optional(z.string()),
+    Entrypoint: z.optional(z.union([z.array(z.string()), z.string(), z.null()])),
+    Cmd: z.optional(z.union([z.array(z.string()), z.string(), z.null()])),
+    Env: z.nullish(z.array(z.string())),
+    Labels: z.nullish(z.record(z.string(), z.string())),
+    WorkingDir: z.nullish(z.string()),
+    User: z.nullish(z.string()),
+});
+
+const WslcInspectHostConfigSchema = z.object({
+    NetworkMode: z.optional(z.string()),
+    Isolation: z.optional(z.string()),
+});
+
+const WslcInspectNetworkSettingsSchema = z.object({
+    Networks: z.nullish(z.record(z.string(), WslcInspectNetworkSchema)),
+    IPAddress: z.optional(z.string()),
+    Ports: z.nullish(z.record(z.string(), z.nullable(z.array(WslcInspectPortHostSchema)))),
+});
+
+const WslcInspectStateSchema = z.object({
+    Status: z.optional(z.string()),
+    Running: z.optional(z.boolean()),
+    ExitCode: z.optional(z.number()),
+    StartedAt: z.optional(z.string()),
+    FinishedAt: z.optional(z.string()),
+});
+
+export const WslcInspectContainerRecordSchema = z.object({
+    Id: z.string(),
+    Name: z.string(),
+    Image: z.optional(z.string()),
+    Created: z.string(),
+    Mounts: z.nullish(z.array(WslcInspectMountSchema)),
+    Labels: z.nullish(z.record(z.string(), z.string())),
+    State: z.optional(WslcInspectStateSchema),
+    Config: WslcInspectConfigSchema,
+    HostConfig: z.optional(WslcInspectHostConfigSchema),
+    NetworkSettings: z.optional(WslcInspectNetworkSettingsSchema),
+    Ports: z.nullish(z.record(z.string(), z.nullable(z.array(WslcInspectPortHostSchema)))),
+});
+
+type WslcInspectContainerRecord = z.infer<typeof WslcInspectContainerRecordSchema>;
+
+export function normalizeWslcInspectContainerRecord(container: WslcInspectContainerRecord, raw: string): InspectContainersItem {
+    const environmentVariables = parseDockerLikeEnvironmentVariables(container.Config?.Env ?? []);
+
+    const networks = Object.entries(container.NetworkSettings?.Networks ?? {}).map<InspectContainersItemNetwork>(([name, network]) => {
+        return {
+            name,
+            gateway: network.Gateway || undefined,
+            ipAddress: normalizeIpAddress(network.IPAddress),
+            macAddress: network.MacAddress || undefined,
+        } satisfies InspectContainersItemNetwork;
+    });
+
+    // wslc emits Ports both at the root and on NetworkSettings; merge them so that
+    // entries appearing only at one level are preserved. NetworkSettings wins on conflict.
+    const portsSource: Record<string, ReadonlyArray<z.infer<typeof WslcInspectPortHostSchema>> | null | undefined> = {
+        ...(container.Ports ?? {}),
+        ...(container.NetworkSettings?.Ports ?? {}),
+    };
+    const ports = Object.entries(portsSource).map<PortBinding>(([rawPort, hostBinding]) => {
+        const [port, protocol] = rawPort.split('/');
+        return {
+            hostIp: normalizeIpAddress(hostBinding?.[0]?.HostIp),
+            hostPort: hostBinding?.[0]?.HostPort ? parseInt(hostBinding[0].HostPort, 10) : undefined,
+            containerPort: parseInt(port, 10),
+            protocol: protocol?.toLowerCase() === 'tcp'
+                ? 'tcp'
+                : protocol?.toLowerCase() === 'udp'
+                    ? 'udp'
+                    : undefined,
+        } satisfies PortBinding;
+    });
+
+    const mounts = (container.Mounts ?? []).reduce<Array<InspectContainersItemMount>>((curMounts, mount) => {
+        switch (mount?.Type) {
+            case 'bind':
+                return [...curMounts, {
+                    type: 'bind',
+                    source: mount.Source,
+                    destination: mount.Destination,
+                    readOnly: mount.ReadWrite === false,
+                } satisfies InspectContainersItemBindMount];
+            case 'volume':
+                return [...curMounts, {
+                    type: 'volume',
+                    source: mount.Name ?? mount.Source ?? '',
+                    destination: mount.Destination,
+                    driver: mount.Driver ?? '',
+                    readOnly: mount.ReadWrite === false,
+                } satisfies InspectContainersItemVolumeMount];
+        }
+
+        return curMounts;
+    }, new Array<InspectContainersItemMount>());
+
+    const labels = container.Labels ?? container.Config?.Labels ?? {};
+
+    const createdAt = dayjs.utc(container.Created);
+    const startedAt = container.State?.StartedAt
+        ? dayjs.utc(container.State.StartedAt)
+        : undefined;
+    const finishedAt = container.State?.FinishedAt
+        ? dayjs.utc(container.State.FinishedAt)
+        : undefined;
+
+    return {
+        id: container.Id,
+        name: container.Name,
+        imageId: container.Image ?? '',
+        image: parseDockerLikeImageName(container.Config?.Image ?? container.Image),
+        isolation: container.HostConfig?.Isolation,
+        status: container.State?.Status,
+        environmentVariables,
+        networks,
+        ipAddress: normalizeIpAddress(container.NetworkSettings?.IPAddress),
+        ports,
+        mounts,
+        labels,
+        entrypoint: toArray(container.Config?.Entrypoint ?? []),
+        command: toArray(container.Config?.Cmd ?? []),
+        currentDirectory: container.Config?.WorkingDir || undefined,
+        createdAt: createdAt.toDate(),
+        startedAt: startedAt && (startedAt.isSame(createdAt) || startedAt.isAfter(createdAt))
+            ? startedAt.toDate()
+            : undefined,
+        finishedAt: finishedAt && (finishedAt.isSame(createdAt) || finishedAt.isAfter(createdAt))
+            ? finishedAt.toDate()
+            : undefined,
+        raw,
+    };
+}

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcInspectImageRecord.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcInspectImageRecord.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { toArray } from '@microsoft/vscode-processutils';
+import * as z from 'zod/mini';
+import { ImageNameInfo, InspectImagesItem, PortBinding } from '../../contracts/ContainerClient';
+import { dayjs } from '../../utils/dayjs';
+import { parseDockerLikeImageName } from '../../utils/parseDockerLikeImageName';
+import { parseDockerLikeEnvironmentVariables } from '../DockerClientBase/parseDockerLikeEnvironmentVariables';
+
+const WslcInspectImageConfigSchema = z.object({
+    Entrypoint: z.optional(z.union([z.array(z.string()), z.string(), z.null()])),
+    Cmd: z.optional(z.union([z.array(z.string()), z.string(), z.null()])),
+    Env: z.nullish(z.array(z.string())),
+    Labels: z.nullish(z.record(z.string(), z.string())),
+    ExposedPorts: z.nullish(z.record(z.string(), z.unknown())),
+    Volumes: z.nullish(z.record(z.string(), z.unknown())),
+    WorkingDir: z.nullish(z.string()),
+    User: z.nullish(z.string()),
+});
+
+export const WslcInspectImageRecordSchema = z.object({
+    Id: z.string(),
+    RepoTags: z.nullish(z.array(z.string())),
+    RepoDigests: z.nullish(z.array(z.string())),
+    Config: z.optional(WslcInspectImageConfigSchema),
+    Architecture: z.optional(z.string()),
+    Os: z.optional(z.string()),
+    Created: z.nullish(z.string()),
+    Size: z.optional(z.number()),
+});
+
+type WslcInspectImageRecord = z.infer<typeof WslcInspectImageRecordSchema>;
+
+export function normalizeWslcInspectImageRecord(image: WslcInspectImageRecord, raw: string): InspectImagesItem {
+    const imageNameInfo: ImageNameInfo = parseDockerLikeImageName(image.RepoTags?.[0]);
+
+    const environmentVariables = parseDockerLikeEnvironmentVariables(image.Config?.Env ?? []);
+
+    const ports = Object.entries(image.Config?.ExposedPorts ?? {}).map<PortBinding>(([rawPort]) => {
+        const [port, protocol] = rawPort.split('/');
+        return {
+            containerPort: parseInt(port, 10),
+            protocol: protocol?.toLowerCase() === 'tcp' ? 'tcp' : protocol?.toLowerCase() === 'udp' ? 'udp' : undefined,
+        };
+    });
+
+    const volumes = Object.entries(image.Config?.Volumes ?? {}).map<string>(([rawVolume]) => rawVolume);
+
+    const labels = image.Config?.Labels ?? {};
+
+    const architecture = image.Architecture?.toLowerCase() === 'amd64'
+        ? 'amd64'
+        : image.Architecture?.toLowerCase() === 'arm64' ? 'arm64' : undefined;
+
+    const os = image.Os?.toLowerCase() === 'linux'
+        ? 'linux'
+        : image.Os?.toLowerCase() === 'windows'
+            ? 'windows'
+            : undefined;
+
+    const repoDigests = image.RepoDigests ?? [];
+    const isLocalImage = !repoDigests.some((digest) => !digest.toLowerCase().startsWith('localhost/'));
+
+    return {
+        id: image.Id,
+        image: imageNameInfo,
+        repoDigests,
+        isLocalImage,
+        environmentVariables,
+        ports,
+        volumes,
+        labels,
+        entrypoint: toArray(image.Config?.Entrypoint ?? []),
+        command: toArray(image.Config?.Cmd ?? []),
+        currentDirectory: image.Config?.WorkingDir || undefined,
+        architecture,
+        operatingSystem: os,
+        createdAt: dayjs(image.Created).toDate(),
+        user: image.Config?.User || undefined,
+        raw,
+    };
+}

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcInspectVolumeRecord.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcInspectVolumeRecord.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as z from 'zod/mini';
+import { InspectVolumesItem } from '../../contracts/ContainerClient';
+
+export const WslcInspectVolumeRecordSchema = z.object({
+    Name: z.string(),
+    Driver: z.optional(z.string()),
+    Mountpoint: z.optional(z.string()),
+    CreatedAt: z.optional(z.string()),
+    Labels: z.nullish(z.record(z.string(), z.string())),
+    Scope: z.optional(z.string()),
+    DriverOpts: z.nullish(z.record(z.string(), z.unknown())),
+    Status: z.nullish(z.record(z.string(), z.unknown())),
+});
+
+type WslcInspectVolumeRecord = z.infer<typeof WslcInspectVolumeRecordSchema>;
+
+export function normalizeWslcInspectVolumeRecord(volume: WslcInspectVolumeRecord, raw: string): InspectVolumesItem {
+    return {
+        name: volume.Name,
+        driver: volume.Driver ?? '',
+        mountpoint: volume.Mountpoint ?? '',
+        createdAt: volume.CreatedAt ? new Date(volume.CreatedAt) : new Date(0),
+        labels: volume.Labels ?? {},
+        scope: volume.Scope ?? 'local',
+        options: (volume.DriverOpts as Record<string, unknown> | undefined) ?? {},
+        raw,
+    };
+}

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcListContainerRecord.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcListContainerRecord.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as z from 'zod/mini';
+
+const WslcListContainerPortBindingSchema = z.object({
+    HostIp: z.optional(z.string()),
+    HostPort: z.optional(z.number()),
+    ContainerPort: z.optional(z.number()),
+    Protocol: z.optional(z.string()),
+});
+
+export const WslcListContainerRecordSchema = z.object({
+    Id: z.string(),
+    Name: z.optional(z.string()),
+    Image: z.optional(z.string()),
+    CreatedAt: z.number(),
+    StateChangedAt: z.optional(z.number()),
+    // State is a numeric enum from wslc; we map it via mapWslcContainerState below.
+    State: z.optional(z.number()),
+    Ports: z.nullish(z.array(WslcListContainerPortBindingSchema)),
+    Labels: z.nullish(z.record(z.string(), z.string())),
+    Networks: z.nullish(z.array(z.string())),
+});
+
+export type WslcListContainerRecord = z.infer<typeof WslcListContainerRecordSchema>;
+
+/**
+ * Map the numeric `State` field returned by `wslc list --format json` to the
+ * string values used in the {@link ListContainersItem} contract.
+ *
+ * Only `2 = running` and `3 = exited` have been observed. wslc has no
+ * `pause`/`unpause` commands, so paused is not expected. Any other value
+ * falls through to `'unknown'` so we don't speculate.
+ */
+export function mapWslcContainerState(state: number | undefined): string {
+    switch (state) {
+        case 2:
+            return 'running';
+        case 3:
+            return 'exited';
+        default:
+            return 'unknown';
+    }
+}

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcListImageRecord.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcListImageRecord.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as z from 'zod/mini';
+
+export const WslcListImageRecordSchema = z.object({
+    Id: z.string(),
+    Repository: z.nullish(z.string()),
+    Tag: z.nullish(z.string()),
+    Size: z.optional(z.number()),
+    // wslc emits Created as a Unix epoch in seconds.
+    Created: z.number(),
+});
+
+export type WslcListImageRecord = z.infer<typeof WslcListImageRecordSchema>;

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcListVolumeRecord.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcListVolumeRecord.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as z from 'zod/mini';
+import { ListVolumeItem } from '../../contracts/ContainerClient';
+
+// `wslc volume list --format json` emits a trimmed shape — only Name and Driver
+// have been observed. Keep this permissive so an additional field appearing in
+// a later wslc release does not break parsing.
+export const WslcListVolumeRecordSchema = z.object({
+    Name: z.string(),
+    Driver: z.optional(z.string()),
+    Mountpoint: z.optional(z.string()),
+    Labels: z.nullish(z.record(z.string(), z.string())),
+    Scope: z.optional(z.string()),
+    CreatedAt: z.optional(z.string()),
+});
+
+type WslcListVolumeRecord = z.infer<typeof WslcListVolumeRecordSchema>;
+
+export function normalizeWslcListVolumeRecord(volume: WslcListVolumeRecord): ListVolumeItem {
+    return {
+        name: volume.Name,
+        driver: volume.Driver ?? '',
+        labels: volume.Labels ?? {},
+        mountpoint: volume.Mountpoint ?? '',
+        scope: volume.Scope ?? 'local',
+        createdAt: volume.CreatedAt ? new Date(volume.CreatedAt) : undefined,
+        size: undefined,
+    };
+}

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcNetworkRecord.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcNetworkRecord.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as z from 'zod/mini';
+import { InspectNetworksItem, ListNetworkItem, NetworkIpamConfig } from '../../contracts/ContainerClient';
+
+const WslcNetworkIpamConfigSchema = z.object({
+    Subnet: z.optional(z.string()),
+    Gateway: z.optional(z.string()),
+});
+
+const WslcNetworkIpamSchema = z.object({
+    Driver: z.optional(z.string()),
+    Config: z.nullish(z.array(WslcNetworkIpamConfigSchema)),
+});
+
+/**
+ * Forgiving schema for wslc network records emitted by both
+ * `wslc network list --format json` and `wslc inspect --type network`.
+ * Field shapes are not fully documented yet so almost everything is optional.
+ */
+export const WslcNetworkRecordSchema = z.object({
+    Id: z.optional(z.string()),
+    Name: z.string(),
+    Driver: z.optional(z.string()),
+    Scope: z.optional(z.string()),
+    Labels: z.nullish(z.record(z.string(), z.string())),
+    IPAM: z.optional(WslcNetworkIpamSchema),
+    EnableIPv6: z.optional(z.boolean()),
+    Internal: z.optional(z.boolean()),
+    Attachable: z.optional(z.boolean()),
+    Ingress: z.optional(z.boolean()),
+    // wslc may emit either an ISO-8601 string or a Unix epoch (seconds).
+    Created: z.optional(z.union([z.string(), z.number()])),
+});
+
+export type WslcNetworkRecord = z.infer<typeof WslcNetworkRecordSchema>;
+
+function parseCreated(value: WslcNetworkRecord['Created']): Date | undefined {
+    if (value === undefined || value === null) {
+        return undefined;
+    }
+    if (typeof value === 'number') {
+        // wslc emits seconds since epoch for some records (consistent with images)
+        return new Date(value * 1000);
+    }
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? undefined : d;
+}
+
+export function normalizeWslcInspectNetworkRecord(network: WslcNetworkRecord, raw: string): InspectNetworksItem {
+    const ipam: NetworkIpamConfig | undefined = network.IPAM
+        ? {
+            driver: network.IPAM.Driver ?? '',
+            config: (network.IPAM.Config ?? [])
+                .filter((c): c is { Subnet: string; Gateway: string } => !!c.Subnet && !!c.Gateway)
+                .map(c => ({ subnet: c.Subnet, gateway: c.Gateway })),
+        }
+        : undefined;
+
+    return {
+        id: network.Id,
+        name: network.Name,
+        driver: network.Driver,
+        scope: network.Scope,
+        labels: network.Labels ?? {},
+        ipam,
+        ipv6: network.EnableIPv6,
+        internal: network.Internal,
+        attachable: network.Attachable,
+        ingress: network.Ingress,
+        createdAt: parseCreated(network.Created),
+        raw,
+    };
+}
+
+export function normalizeWslcListNetworkRecord(network: WslcNetworkRecord): ListNetworkItem {
+    return {
+        id: network.Id,
+        name: network.Name,
+        driver: network.Driver,
+        labels: network.Labels ?? {},
+        scope: network.Scope,
+        ipv6: network.EnableIPv6,
+        internal: network.Internal,
+        createdAt: parseCreated(network.Created),
+    };
+}

--- a/packages/vscode-container-client/src/index.ts
+++ b/packages/vscode-container-client/src/index.ts
@@ -7,6 +7,7 @@ export * from './clients/DockerClient/DockerClient';
 export * from './clients/DockerComposeClient/DockerComposeClient';
 export * from './clients/PodmanClient/PodmanClient';
 export * from './clients/PodmanComposeClient/PodmanComposeClient';
+export * from './clients/WslcClient/WslcClient';
 export * from './commandRunners/shellStream';
 export * from './commandRunners/wslStream';
 export * from './contracts/CommandRunner';

--- a/packages/vscode-container-client/src/test/ContainersClientE2E.test.ts
+++ b/packages/vscode-container-client/src/test/ContainersClientE2E.test.ts
@@ -12,6 +12,7 @@ import * as stream from 'stream';
 import { FileType } from '../typings/FileType';
 import { DockerClient } from '../clients/DockerClient/DockerClient';
 import { PodmanClient } from '../clients/PodmanClient/PodmanClient';
+import { WslcClient } from '../clients/WslcClient/WslcClient';
 import { ShellStreamCommandRunnerFactory, ShellStreamCommandRunnerOptions } from '../commandRunners/shellStream';
 import { WslShellCommandRunnerFactory, WslShellCommandRunnerOptions } from '../commandRunners/wslStream';
 import { IContainersClient, ListContainersItem, ListImagesItem, ListNetworkItem, ListVolumeItem } from '../contracts/ContainerClient';
@@ -28,7 +29,11 @@ const runInWsl: boolean = (process.env.RUN_IN_WSL === '1' || process.env.RUN_IN_
 
 // No need to modify below this
 
-export type ClientType = 'docker' | 'podman';
+export type ClientType = 'docker' | 'podman' | 'wslc';
+
+// wslc does not support the `--expose` flag on `run`, but it does support
+// network create/list/inspect/remove/prune.
+const supportsExposeFlag = clientTypeToTest !== 'wslc';
 
 describe('(integration) ContainersClientE2E', function () {
 
@@ -45,6 +50,8 @@ describe('(integration) ContainersClientE2E', function () {
             client = new DockerClient();
         } else if (clientTypeToTest === 'podman') {
             client = new PodmanClient();
+        } else if (clientTypeToTest === 'wslc') {
+            client = new WslcClient();
         } else {
             throw new Error('Invalid clientTypeToTest');
         }
@@ -346,8 +353,8 @@ describe('(integration) ContainersClientE2E', function () {
                         { type: 'volume', source: testContainerVolumeName, destination: '/data2', readOnly: false }
                     ],
                     ports: [{ hostPort: 8080, containerPort: 80 }],
-                    exposePorts: [3000], // Uses the `--expose` flag to expose a port without binding it
-                    publishAllPorts: true, // Which will then get bound to a random port on the host, due to this flag
+                    exposePorts: supportsExposeFlag ? [3000] : undefined, // wslc has no --expose flag
+                    publishAllPorts: true, // exposed ports get random host bindings
                 })
             ))!;
         });
@@ -404,7 +411,10 @@ describe('(integration) ContainersClientE2E', function () {
             // Validate the ports
             expect(container.ports).to.be.an('array');
             expect(container.ports.some(p => p.hostPort === 8080 && p.containerPort === 80)).to.be.true;
-            expect(container.ports.some(p => p.containerPort === 3000 && !!p.hostPort && p.hostPort > 0 && p.hostPort < 65536)).to.be.true; // Exposed port with random binding
+            if (supportsExposeFlag) {
+                // wslc has no --expose flag, so no random-binding port to validate
+                expect(container.ports.some(p => p.containerPort === 3000 && !!p.hostPort && p.hostPort > 0 && p.hostPort < 65536)).to.be.true; // Exposed port with random binding
+            }
 
             // Volumes and bind mounts do not show up in ListContainersCommand, so we won't validate those here
         });
@@ -440,13 +450,19 @@ describe('(integration) ContainersClientE2E', function () {
             expect(container.mounts.some(m => m.type === 'bind' && m.source === testContainerBindMountSource && m.destination === '/data1' && m.readOnly === true)).to.be.true;
 
             // Validate the volume
-            expect(container.mounts).to.be.an('array');
-            expect(container.mounts.some(m => m.type === 'volume' && m.source === testContainerVolumeName && m.destination === '/data2' && m.readOnly === false)).to.be.true;
+            // NOTE: wslc omits named-volume mounts from `inspect` output (only bind mounts appear),
+            // even though the volume is functionally mounted. Skip this assertion for wslc.
+            if (clientTypeToTest !== 'wslc') {
+                expect(container.mounts).to.be.an('array');
+                expect(container.mounts.some(m => m.type === 'volume' && m.source === testContainerVolumeName && m.destination === '/data2' && m.readOnly === false)).to.be.true;
+            }
 
             // Validate the ports
             expect(container.ports).to.be.an('array');
             expect(container.ports.some(p => p.hostPort === 8080 && p.containerPort === 80)).to.be.true;
-            expect(container.ports.some(p => p.containerPort === 3000 && !!p.hostPort && p.hostPort > 0 && p.hostPort < 65536)).to.be.true; // Exposed port with random binding
+            if (supportsExposeFlag) {
+                expect(container.ports.some(p => p.containerPort === 3000 && !!p.hostPort && p.hostPort > 0 && p.hostPort < 65536)).to.be.true; // Exposed port with random binding
+            }
         });
 
         it('ExecContainerCommand', async function () {
@@ -535,6 +551,10 @@ describe('(integration) ContainersClientE2E', function () {
         });
 
         it('RestartContainersCommand', async function () {
+            if (clientTypeToTest === 'wslc') {
+                this.skip(); // wslc has no `restart` subcommand
+            }
+
             // Restart the container
             const restartedContainers = await defaultRunner.getCommandRunner()(
                 client.restartContainers({ container: [testContainerId], time: 1 })
@@ -838,6 +858,10 @@ describe('(integration) ContainersClientE2E', function () {
         let container: string | undefined;
 
         before('Events', async function () {
+            if (clientTypeToTest === 'wslc') {
+                this.skip(); // wslc has no `events` subcommand
+            }
+
             // Create a container so that the event stream has something to report
             container = await defaultRunner.getCommandRunner()(
                 client.runContainer({

--- a/packages/vscode-container-client/src/test/WslcClient.test.ts
+++ b/packages/vscode-container-client/src/test/WslcClient.test.ts
@@ -1,0 +1,562 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ShellQuoting } from '@microsoft/vscode-processutils';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { WslcClient } from '../clients/WslcClient/WslcClient';
+import { CommandNotSupportedError } from '../utils/CommandNotSupportedError';
+
+function asStrings(args: ReadonlyArray<string | { value: string; quoting: ShellQuoting }>): string[] {
+    return args.map(a => typeof a === 'string' ? a : a.value);
+}
+
+async function expectRejection(promiseOrFn: Promise<unknown> | (() => Promise<unknown>)): Promise<void> {
+    let caught: unknown;
+    try {
+        const promise = typeof promiseOrFn === 'function' ? promiseOrFn() : promiseOrFn;
+        await promise;
+    } catch (err) {
+        caught = err;
+    }
+    expect(caught).to.be.instanceOf(CommandNotSupportedError);
+}
+
+describe('(unit) WslcClient', () => {
+    const client = new WslcClient();
+
+    it('Has the expected ClientId and default command', () => {
+        expect(WslcClient.ClientId).to.equal('com.microsoft.visualstudio.containers.wslc');
+        expect(client.id).to.equal('com.microsoft.visualstudio.containers.wslc');
+        expect(client.commandName).to.equal('wslc');
+        expect(client.displayName).to.equal('WSLC');
+    });
+
+    describe('#listContainers()', () => {
+        it('Produces `list --format json` args', async () => {
+            const response = await client.listContainers({ all: true });
+            expect(response.command).to.equal('wslc');
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['list', '--all', '--format', 'json']);
+        });
+
+        it('Parses wslc list output', async () => {
+            const response = await client.listContainers({ all: true });
+            const items = await response.parse(
+                JSON.stringify([
+                    {
+                        Id: 'abc123',
+                        Name: 'cool_yonath',
+                        Image: 'alpine:latest',
+                        State: 2,
+                        CreatedAt: 1700000000,
+                        Ports: [],
+                    },
+                    {
+                        Id: 'def456',
+                        Name: 'silly_einstein',
+                        Image: 'busybox:1.36',
+                        State: 3,
+                        CreatedAt: 1700000100,
+                    },
+                ]),
+                true,
+            );
+            expect(items).to.have.lengthOf(2);
+            expect(items[0]).to.include({ id: 'abc123', name: 'cool_yonath', state: 'running' });
+            expect(items[1]).to.include({ id: 'def456', name: 'silly_einstein', state: 'exited' });
+        });
+
+        it('Emits --filter args for supported filters', async () => {
+            const response = await client.listContainers({
+                all: true,
+                running: true,
+                labels: { 'com.example': 'x' },
+                names: ['n1'],
+                imageAncestors: ['img1'],
+                volumes: ['vol1'],
+                networks: ['net1'],
+            });
+            const args = asStrings(response.args);
+            expect(args).to.include('--filter');
+            expect(args).to.include('status=running');
+            expect(args).to.include('label=com.example=x');
+            expect(args).to.include('name=n1');
+            expect(args).to.include('ancestor=img1');
+            expect(args).to.include('volume=vol1');
+            expect(args).to.include('network=net1');
+        });
+
+        it('Skips a malformed record in non-strict mode instead of dropping the whole list', async () => {
+            const response = await client.listContainers({ all: true });
+            const items = await response.parse(
+                JSON.stringify([
+                    { Id: 'good', Name: 'ok', Image: 'alpine', State: 2, CreatedAt: 1700000000, Ports: [] },
+                    { Name: 'missing-id-and-createdAt' }, // invalid: missing required fields
+                ]),
+                false,
+            );
+            expect(items).to.have.lengthOf(1);
+            expect(items[0]).to.include({ id: 'good' });
+        });
+    });
+
+    describe('#listImages()', () => {
+        it('Produces `images --format json` args', async () => {
+            const response = await client.listImages({});
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['images', '--format', 'json']);
+        });
+
+        it('Emits --filter args for dangling / reference / label', async () => {
+            const response = await client.listImages({
+                dangling: false,
+                references: ['alpine'],
+                labels: { 'com.example': 'x' },
+            });
+            const args = asStrings(response.args);
+            expect(args).to.include('--filter');
+            expect(args).to.include('dangling=false');
+            expect(args).to.include('reference=alpine');
+            expect(args).to.include('label=com.example=x');
+        });
+
+        it('Skips a malformed record in non-strict mode', async () => {
+            const response = await client.listImages({});
+            const items = await response.parse(
+                JSON.stringify([
+                    { Id: 'sha256:aaaa', Repository: 'alpine', Tag: 'latest', Created: 1700000000, Size: 1 },
+                    { Repository: 'no-id' }, // invalid: missing required Id/Created
+                ]),
+                false,
+            );
+            expect(items).to.have.lengthOf(1);
+            expect(items[0]).to.have.property('id', 'sha256:aaaa');
+        });
+
+        it('Parses wslc images output', async () => {
+            const response = await client.listImages({});
+            const items = await response.parse(
+                JSON.stringify([
+                    {
+                        Id: 'sha256:aaaa',
+                        Repository: 'alpine',
+                        Tag: 'latest',
+                        Created: 1700000000,
+                        Size: 7000000,
+                    },
+                ]),
+                true,
+            );
+            expect(items).to.have.lengthOf(1);
+            expect(items[0]).to.have.property('id', 'sha256:aaaa');
+            expect(items[0]).to.have.property('createdAt');
+            expect(items[0].createdAt.getDay()).to.not.be.NaN;
+        });
+    });
+
+    describe('#removeImages()', () => {
+        it('Produces `rmi` args', async () => {
+            const response = await client.removeImages({ imageRefs: ['alpine:latest'], force: true });
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['rmi', '--force', 'alpine:latest']);
+        });
+    });
+
+    describe('#removeContainers()', () => {
+        it('Produces `remove` args', async () => {
+            const response = await client.removeContainers({ containers: ['abc'], force: true });
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['remove', '--force', 'abc']);
+        });
+    });
+
+    describe('#inspectContainers()', () => {
+        it('Produces `inspect --type container` args', async () => {
+            const response = await client.inspectContainers({ containers: ['abc'] });
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['inspect', '--type', 'container', 'abc']);
+        });
+
+        it('Parses single-object inspect payload', async () => {
+            const response = await client.inspectContainers({ containers: ['abc'] });
+            const items = await response.parse(
+                JSON.stringify({
+                    Id: 'abc',
+                    Name: '/foo',
+                    Image: 'alpine:latest',
+                    Created: '2024-01-01T00:00:00Z',
+                    Config: {},
+                    State: { Status: 'running' },
+                    NetworkSettings: { Ports: {} },
+                    HostConfig: {},
+                    Mounts: [],
+                }),
+                false,
+            );
+            expect(items).to.have.lengthOf(1);
+            expect(items[0]).to.have.property('id', 'abc');
+        });
+
+        it('Reads bind-mount readOnly from the `ReadWrite` field', async () => {
+            const response = await client.inspectContainers({ containers: ['abc'] });
+            const items = await response.parse(
+                JSON.stringify({
+                    Id: 'abc',
+                    Name: '/foo',
+                    Image: 'alpine:latest',
+                    Created: '2024-01-01T00:00:00Z',
+                    Config: {},
+                    State: { Status: 'running' },
+                    NetworkSettings: { Ports: {} },
+                    HostConfig: {},
+                    Mounts: [
+                        { Type: 'bind', Source: 'C:\\ro', Destination: '/ro', ReadWrite: false },
+                        { Type: 'bind', Source: 'C:\\rw', Destination: '/rw', ReadWrite: true },
+                    ],
+                }),
+                false,
+            );
+            const mounts = items[0].mounts;
+            expect(mounts.find(m => m.destination === '/ro')?.readOnly).to.equal(true);
+            expect(mounts.find(m => m.destination === '/rw')?.readOnly).to.equal(false);
+        });
+    });
+
+    describe('#inspectImages()', () => {
+        it('Produces `inspect --type image` args', async () => {
+            const response = await client.inspectImages({ imageRefs: ['alpine:latest'] });
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['inspect', '--type', 'image', 'alpine:latest']);
+        });
+    });
+
+    describe('#version()', () => {
+        it('Produces `version` with no format flag', async () => {
+            const response = await client.version({});
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['version']);
+        });
+
+        it('Parses plain-text version output', async () => {
+            const response = await client.version({});
+            const parsed = await response.parse('wslc 2.9.3.0\n', true);
+            expect(parsed).to.have.property('client', '2.9.3.0');
+            expect(parsed).to.have.property('server', undefined);
+        });
+    });
+
+    describe('#checkInstall()', () => {
+        it('Produces `--version` args', async () => {
+            const response = await client.checkInstall({});
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['--version']);
+        });
+    });
+
+    describe('#buildImage()', () => {
+        it('Produces `build` args without per-resource `image` prefix', async () => {
+            const response = await client.buildImage({ path: '.' });
+            const args = asStrings(response.args);
+            expect(args[0]).to.equal('build');
+            expect(args).to.include('.');
+        });
+    });
+
+    describe('#info()', () => {
+        it('Synthesizes a linux InfoItem because wslc has no info command', async () => {
+            const response = await client.info({});
+            const item = await response.parse('whatever', false);
+            expect(item).to.have.property('osType', 'linux');
+        });
+    });
+
+    describe('#createNetwork()', () => {
+        it('Produces `network create <name>` args', async () => {
+            const response = await client.createNetwork({ name: 'my-net' });
+            expect(response.command).to.equal('wslc');
+            expect(asStrings(response.args)).to.deep.equal(['network', 'create', 'my-net']);
+        });
+
+        it('Includes --driver when provided', async () => {
+            const response = await client.createNetwork({ name: 'my-net', driver: 'bridge' });
+            expect(asStrings(response.args)).to.deep.equal(['network', 'create', '--driver', 'bridge', 'my-net']);
+        });
+    });
+
+    describe('#listNetworks()', () => {
+        it('Produces `network list --format json` args', async () => {
+            const response = await client.listNetworks({});
+            expect(response.command).to.equal('wslc');
+            expect(asStrings(response.args)).to.deep.equal(['network', 'list', '--format', 'json']);
+        });
+
+        it('Ignores filter options (wslc has no filter flags)', async () => {
+            const response = await client.listNetworks({ driver: 'bridge', labels: { foo: 'bar' } });
+            expect(asStrings(response.args)).to.deep.equal(['network', 'list', '--format', 'json']);
+        });
+
+        it('Parses wslc network list JSON output', async () => {
+            const response = await client.listNetworks({});
+            const items = await response.parse(
+                JSON.stringify([
+                    {
+                        Id: 'net-abc',
+                        Name: 'bridge',
+                        Driver: 'bridge',
+                        Scope: 'local',
+                        Labels: { foo: 'bar' },
+                        EnableIPv6: false,
+                        Internal: false,
+                    },
+                    {
+                        Name: 'host',
+                        Driver: 'host',
+                    },
+                ]),
+                true,
+            );
+            expect(items).to.have.lengthOf(2);
+            expect(items[0]).to.include({ id: 'net-abc', name: 'bridge', driver: 'bridge', scope: 'local', ipv6: false, internal: false });
+            expect(items[0].labels).to.deep.equal({ foo: 'bar' });
+            expect(items[1]).to.include({ name: 'host', driver: 'host' });
+        });
+
+        it('Accepts a single-object payload', async () => {
+            const response = await client.listNetworks({});
+            const items = await response.parse(
+                JSON.stringify({ Name: 'bridge', Driver: 'bridge' }),
+                true,
+            );
+            expect(items).to.have.lengthOf(1);
+            expect(items[0]).to.include({ name: 'bridge', driver: 'bridge' });
+        });
+    });
+
+    describe('#removeNetworks()', () => {
+        it('Produces `network remove --force <names...>` args', async () => {
+            const response = await client.removeNetworks({ networks: ['a', 'b'], force: true });
+            expect(asStrings(response.args)).to.deep.equal(['network', 'remove', '--force', 'a', 'b']);
+        });
+    });
+
+    describe('#inspectNetworks()', () => {
+        it('Produces `inspect --type network <name>` args for a single network', async () => {
+            const response = await client.inspectNetworks({ networks: ['bridge'] });
+            expect(asStrings(response.args)).to.deep.equal(['inspect', '--type', 'network', 'bridge']);
+        });
+
+        it('Produces multi-id `inspect --type network <names...>` args', async () => {
+            const response = await client.inspectNetworks({ networks: ['bridge', 'host'] });
+            expect(asStrings(response.args)).to.deep.equal(['inspect', '--type', 'network', 'bridge', 'host']);
+        });
+
+        it('Parses single-object inspect payload', async () => {
+            const response = await client.inspectNetworks({ networks: ['bridge'] });
+            const items = await response.parse(
+                JSON.stringify({
+                    Id: 'net-abc',
+                    Name: 'bridge',
+                    Driver: 'bridge',
+                    Scope: 'local',
+                    Labels: {},
+                    IPAM: { Driver: 'default', Config: [{ Subnet: '10.0.0.0/24', Gateway: '10.0.0.1' }] },
+                    EnableIPv6: false,
+                    Internal: false,
+                    Attachable: true,
+                    Ingress: false,
+                    Created: '2026-01-02T03:04:05Z',
+                }),
+                true,
+            );
+            expect(items).to.have.lengthOf(1);
+            const network = items[0];
+            expect(network).to.include({ id: 'net-abc', name: 'bridge', driver: 'bridge', scope: 'local', ipv6: false, internal: false, attachable: true, ingress: false });
+            expect(network.ipam).to.deep.equal({ driver: 'default', config: [{ subnet: '10.0.0.0/24', gateway: '10.0.0.1' }] });
+            expect(network.createdAt).to.be.instanceOf(Date);
+            expect(network.raw).to.be.a('string');
+        });
+    });
+
+    describe('Unsupported commands', () => {
+        it('getEventStream rejects with CommandNotSupportedError', async () => {
+            await expectRejection(client.getEventStream({}));
+        });
+
+        it('restartContainers rejects with CommandNotSupportedError', async () => {
+            await expectRejection(client.restartContainers({ container: ['abc'] }));
+        });
+    });
+
+    describe('#pruneVolumes()', () => {
+        it('Produces `volume prune` args without --force', async () => {
+            const response = await client.pruneVolumes({});
+            expect(asStrings(response.args)).to.deep.equal(['volume', 'prune']);
+        });
+
+        it('Parses `Deleted: <name>` output', async () => {
+            const response = await client.pruneVolumes({});
+            const result = await response.parse('Deleted: vol-a\nDeleted: vol-b\n\nTotal reclaimed space: 0 B', true);
+            expect(result.volumesDeleted).to.deep.equal(['vol-a', 'vol-b']);
+        });
+    });
+
+    describe('#pruneNetworks()', () => {
+        it('Produces `network prune` args without --force', async () => {
+            const response = await client.pruneNetworks({});
+            expect(asStrings(response.args)).to.deep.equal(['network', 'prune']);
+        });
+
+        it('Parses `Deleted: <name>` output', async () => {
+            const response = await client.pruneNetworks({});
+            const result = await response.parse('Deleted: net-a\nDeleted: net-b', true);
+            expect(result.networksDeleted).to.deep.equal(['net-a', 'net-b']);
+        });
+    });
+
+    describe('#pullImage()', () => {
+        it('Produces `pull <ref>` args (no --all-tags / --disable-content-trust)', async () => {
+            const response = await client.pullImage({ imageRef: 'alpine:latest', allTags: true, disableContentTrust: true });
+            expect(asStrings(response.args)).to.deep.equal(['pull', 'alpine:latest']);
+        });
+    });
+
+    describe('#pruneImages()', () => {
+        it('Produces `image prune` args without --force', async () => {
+            const response = await client.pruneImages({});
+            expect(asStrings(response.args)).to.deep.equal(['image', 'prune']);
+        });
+
+        it('Includes --all when requested', async () => {
+            const response = await client.pruneImages({ all: true });
+            expect(asStrings(response.args)).to.deep.equal(['image', 'prune', '--all']);
+        });
+    });
+
+    describe('#pruneContainers()', () => {
+        it('Produces `container prune` args without --force or --filter', async () => {
+            const response = await client.pruneContainers({});
+            expect(asStrings(response.args)).to.deep.equal(['container', 'prune']);
+        });
+    });
+
+    describe('#removeVolumes()', () => {
+        it('Produces `volume rm --force <names...>` args', async () => {
+            const response = await client.removeVolumes({ volumes: ['v1', 'v2'], force: true });
+            expect(asStrings(response.args)).to.deep.equal(['volume', 'rm', '--force', 'v1', 'v2']);
+        });
+    });
+
+    describe('#runContainer()', () => {
+        it('Emits supported flags', async () => {
+            const response = await client.runContainer({
+                imageRef: 'alpine:latest',
+                name: 'demo',
+                detached: true,
+                interactive: false,
+                removeOnExit: true,
+                network: 'mynet',
+                ports: [{ hostPort: 8080, containerPort: 80, protocol: 'tcp' }],
+                publishAllPorts: true,
+                labels: { env: 'dev' },
+                environmentVariables: { FOO: 'bar' },
+                entrypoint: '/bin/sh',
+            });
+            const args = asStrings(response.args);
+            expect(args).to.include('run');
+            expect(args).to.include('--detach');
+            expect(args).to.include('--rm');
+            expect(args).to.include('--name');
+            expect(args).to.include('demo');
+            expect(args).to.include('--network');
+            expect(args).to.include('mynet');
+            expect(args).to.include('--publish');
+            expect(args).to.include('--publish-all');
+            expect(args).to.include('--label');
+            expect(args).to.include('env=dev');
+            expect(args).to.include('--env');
+            expect(args).to.include('FOO=bar');
+            expect(args).to.include('--entrypoint');
+            expect(args).to.include('/bin/sh');
+            expect(args).to.include('alpine:latest');
+        });
+
+        it('Emits --network-alias when set', async () => {
+            const response = await client.runContainer({
+                imageRef: 'alpine:latest',
+                network: 'mynet',
+                networkAlias: 'myalias',
+            });
+            const args = asStrings(response.args);
+            expect(args).to.include('--network-alias');
+            expect(args).to.include('myalias');
+        });
+
+        it('Throws when addHost has entries', async () => {
+            await expectRejection(() => client.runContainer({
+                imageRef: 'alpine:latest',
+                addHost: [{ hostname: 'foo.local', ip: '127.0.0.1' }],
+            }));
+        });
+
+        it('Throws when exposePorts has entries', async () => {
+            await expectRejection(() => client.runContainer({
+                imageRef: 'alpine:latest',
+                exposePorts: [3000],
+            }));
+        });
+
+        it('Throws when platform is set', async () => {
+            await expectRejection(() => client.runContainer({
+                imageRef: 'alpine:latest',
+                platform: { os: 'linux' },
+            }));
+        });
+
+        it('Emits --volume (not --mount) for mounts', async () => {
+            const response = await client.runContainer({
+                imageRef: 'alpine:latest',
+                mounts: [
+                    { type: 'bind', source: 'C:\\src', destination: '/src', readOnly: false },
+                    { type: 'volume', source: 'data', destination: '/data', readOnly: true },
+                ],
+            });
+            const args = asStrings(response.args);
+            expect(args).to.include('--volume');
+            expect(args).to.include('C:\\src:/src');
+            expect(args).to.include('data:/data:ro');
+            expect(args).to.not.include('--mount');
+        });
+    });
+
+    describe('#readFile()', () => {
+        it('Tars the file via `container exec` (wslc has no cp-to-stdout)', async () => {
+            const response = await client.readFile({ container: 'abc', path: '/tmp/sub/file.txt' });
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['container', 'exec', 'abc', 'tar', '-cf', '-', '-C', '/tmp/sub', 'file.txt']);
+        });
+
+        it('Handles a root-level file path', async () => {
+            const response = await client.readFile({ container: 'abc', path: '/file.txt' });
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['container', 'exec', 'abc', 'tar', '-cf', '-', '-C', '/', 'file.txt']);
+        });
+    });
+
+    describe('#writeFile()', () => {
+        it('Produces `container cp - <container>:<dir>` for stdin tar input', async () => {
+            const response = await client.writeFile({ container: 'abc', path: '/tmp/dest' });
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['container', 'cp', '-', 'abc:/tmp/dest']);
+        });
+
+        it('Uses the provided input file when set', async () => {
+            const response = await client.writeFile({ container: 'abc', path: '/tmp/dest', inputFile: 'C:\\local.tar' });
+            const args = asStrings(response.args);
+            expect(args).to.deep.equal(['container', 'cp', 'C:\\local.tar', 'abc:/tmp/dest']);
+        });
+    });
+});


### PR DESCRIPTION
###  Add  WslcClient  for the Windows Subsystem for Linux Container ( wslc ) CLI

###  Description

 Adds a new  WslcClient  to  @microsoft/vscode-container-client  that supports  wslc  (the Windows Subsystem for Linux Container CLI) as an alternative  container runtime. It is Windows-only and subclasses  DockerClientBase , overriding only the verbs, arg-builders, and parsers that differ from Docker.

 This is the extensibility half of the feature; the consumer changes live in microsoft/vscode-containers#.

 **What's added**

 •  WslcClient  

 **Key differences from Docker that the client handles**

 • CLI is Windows-only.
 •  run  uses  --volume  (not  --mount ) and supports  --network-alias ; throws  CommandNotSupportedError  for the unsupported     --add-host / --expose / --platform .
 • List filters ( label ,  status ,  name ,  ancestor ,  volume ,  network ; image  dangling / reference ) are emitted
 • No  info / events / context / restart  subcommands — these reject with  CommandNotSupportedError  ( info  synthesizes a Linux  InfoItem  to keep     osType -dependent callers working).

 **Shared base change**

 • Bug fix:  getExecContainerCommandArgs  now emits  --detach  instead of the misspelled  --detached , matching the real Docker/Podman CLI flag (affects    all clients).

Part of microsoft/vscode-containers#501
